### PR TITLE
[TPP-1635] 心拍変動API

### DIFF
--- a/examples/sample/src/index.ts
+++ b/examples/sample/src/index.ts
@@ -114,7 +114,7 @@ app.get('/fitbit/sleep', async (req, res) => {
 
   // 睡眠記録を取得
   const sleep = await client.sleep.getSleepLog(
-    '2024-10-07',
+    '2025-10-01',
     profile.user.offsetFromUTCMillis,
   );
   res.status(200).json(sleep);
@@ -138,7 +138,7 @@ app.get('/fitbit/heartrate/summary', async (req, res) => {
   // アクセストークンの更新
   await client.auth.refreshAccessToken();
 
-  const hRVSummary = await client.heartRate.getHRVSummary('2024-10-07');
+  const hRVSummary = await client.heartRate.getHRVSummary('2025-08-27');
 
   console.log('summary', hRVSummary);
   res.status(200).json(hRVSummary);

--- a/examples/sample/src/index.ts
+++ b/examples/sample/src/index.ts
@@ -138,7 +138,7 @@ app.get('/fitbit/heartrate/summary', async (req, res) => {
   // アクセストークンの更新
   await client.auth.refreshAccessToken();
 
-  const hRVSummary = await client.heartRate.getHRVSummary('2025-08-27');
+  const hRVSummary = await client.heartRate.getHRVSummary('2024-10-07');
 
   console.log('summary', hRVSummary);
   res.status(200).json(hRVSummary);

--- a/examples/sample/src/index.ts
+++ b/examples/sample/src/index.ts
@@ -9,6 +9,7 @@ dotenv.config({ path: '.env.local' });
 const CLIENT_ID = process.env.CLIENT_ID as string;
 const CLIENT_SECRET = process.env.CLIENT_SECRET as string;
 const REDIRECT_URI = process.env.REDIRECT_URI as string;
+const offsetFromUTCMillis = 9 * 60 * 60 * 1000;
 
 if (CLIENT_ID == null || CLIENT_SECRET == null || REDIRECT_URI == null) {
   throw new Error('環境変数が設定されていません');
@@ -160,7 +161,10 @@ app.get('/fitbit/heartrate/intraday', async (req, res) => {
   // アクセストークンの更新
   await client.auth.refreshAccessToken();
 
-  const hRVIntraday = await client.heartRate.getHRVIntraday('2024-10-07');
+  const hRVIntraday = await client.heartRate.getHRVIntraday(
+    '2025-08-27',
+    offsetFromUTCMillis,
+  );
   res.status(200).json(hRVIntraday);
 });
 

--- a/examples/sample/src/index.ts
+++ b/examples/sample/src/index.ts
@@ -78,6 +78,12 @@ app.get('/auth/callback', async (req, res) => {
     console.log(
       'こちらにsleepから睡眠記録を閲覧できます。 http://localhost:3000/fitbit/sleep',
     );
+    console.log(
+      'HRVSummaryはこちらから閲覧できます。 http://localhost:3000/fitbit/heartrate/summary',
+    );
+    console.log(
+      'HRVIntradayはこちらから閲覧できます。 http://localhost:3000/fitbit/heartrate/intraday',
+    );
   } catch (error) {
     console.error(error);
     res.status(500).send('認証エラーが発生しました');
@@ -112,6 +118,53 @@ app.get('/fitbit/sleep', async (req, res) => {
     profile.user.offsetFromUTCMillis,
   );
   res.status(200).json(sleep);
+});
+
+app.get('/fitbit/heartrate/summary', async (req, res) => {
+  // トークンを取得
+  const refreshToken = database.findRefreshToken();
+  if (!refreshToken) {
+    res.status(400).send('トークンがありません');
+    return;
+  }
+
+  // FitbitClientのインスタンスを作成
+  const client = new FitbitClient({
+    clientId: CLIENT_ID,
+    clientSecret: CLIENT_SECRET,
+    token: { refreshToken },
+  });
+
+  // アクセストークンの更新
+  await client.auth.refreshAccessToken();
+
+  const hRVSummary = await client.heartRate.getHRVSummary('2024-10-07');
+
+  console.log('summary', hRVSummary);
+  res.status(200).json(hRVSummary);
+});
+
+app.get('/fitbit/heartrate/intraday', async (req, res) => {
+  // トークンを取得
+  const refreshToken = database.findRefreshToken();
+  if (!refreshToken) {
+    res.status(400).send('トークンがありません');
+    return;
+  }
+
+  // FitbitClientのインスタンスを作成
+  const client = new FitbitClient({
+    clientId: CLIENT_ID,
+    clientSecret: CLIENT_SECRET,
+    token: { refreshToken },
+  });
+
+  // アクセストークンの更新
+  await client.auth.refreshAccessToken();
+
+  const hRVIntraday = await client.heartRate.getHRVIntraday('2024-10-07');
+  console.log('intraday', hRVIntraday);
+  res.status(200).json(hRVIntraday);
 });
 
 // サーバー起動

--- a/examples/sample/src/index.ts
+++ b/examples/sample/src/index.ts
@@ -139,8 +139,6 @@ app.get('/fitbit/heartrate/summary', async (req, res) => {
   await client.auth.refreshAccessToken();
 
   const hRVSummary = await client.heartRate.getHRVSummary('2024-10-07');
-
-  console.log('summary', hRVSummary);
   res.status(200).json(hRVSummary);
 });
 
@@ -163,7 +161,6 @@ app.get('/fitbit/heartrate/intraday', async (req, res) => {
   await client.auth.refreshAccessToken();
 
   const hRVIntraday = await client.heartRate.getHRVIntraday('2024-10-07');
-  console.log('intraday', hRVIntraday);
   res.status(200).json(hRVIntraday);
 });
 

--- a/src/apis/heart-rate.api.ts
+++ b/src/apis/heart-rate.api.ts
@@ -68,6 +68,11 @@ export class HeartRateApi extends BaseApi {
     return this.get(path, options);
   }
 
+  /**
+   * https://dev.fitbit.com/build/reference/web-api/heartrate-variability/get-hrv-summary-by-date/
+   * @param request
+   * @param options
+   */
   async getHRVSummaryByDate(
     request: GetHRVSummaryByDateRequest,
     options: TokenRequestOptions,
@@ -87,6 +92,11 @@ export class HeartRateApi extends BaseApi {
     return this.get(path, options);
   }
 
+  /**
+   * https://dev.fitbit.com/build/reference/web-api/intraday/get-hrv-intraday-by-date/
+   * @param request
+   * @param options
+   */
   async getHRVIntradayByDate(
     request: GetHRVIntradayRequest,
     options: TokenRequestOptions,

--- a/src/apis/heart-rate.api.ts
+++ b/src/apis/heart-rate.api.ts
@@ -102,7 +102,7 @@ export class HeartRateApi extends BaseApi {
   ): Promise<unknown> {
     const { localDate } = request;
     validateDateString(localDate);
-    const path = `/1/user/-/hrv/${localDate}/all.json`;
+    const path = `/1/user/-/hrv/date/${localDate}/all.json`;
     return this.get(path, options);
   }
 }

--- a/src/apis/heart-rate.api.ts
+++ b/src/apis/heart-rate.api.ts
@@ -1,6 +1,11 @@
 import { BaseApi, TokenRequestOptions } from './base.api';
 import { DetailLevel } from '../types';
-import { HeartRateResponse, HeartRateResponseFromJson } from '../models';
+import {
+  HeartRateResponse,
+  HeartRateResponseFromJson,
+  HRVResponse,
+  HRVResponseFromJson,
+} from '../models';
 import { validateDateString } from '../utils/date.utils';
 
 interface GetHeartRateIntradayByDateRequest {
@@ -10,6 +15,22 @@ interface GetHeartRateIntradayByDateRequest {
    */
   localDate: string;
   detailLevel: DetailLevel;
+}
+
+interface GetHRVSummaryByDateRequest {
+  /**
+   * 端末のタイムゾーンでの日付
+   * 'YYYY-MM-DD'
+   */
+  localDate: string;
+}
+
+interface GetHRVIntradayRequest {
+  /**
+   * 端末のタイムゾーンでの日付
+   * 'YYYY-MM-DD'
+   */
+  localDate: string;
 }
 
 export class HeartRateApi extends BaseApi {
@@ -42,6 +63,44 @@ export class HeartRateApi extends BaseApi {
     const { localDate, detailLevel } = request;
     validateDateString(localDate);
     const path = `/1/user/-/activities/heart/date/${localDate}/1d/${detailLevel}.json`;
+    return this.get(path, options);
+  }
+
+  async getHRVSummaryByDate(
+    request: GetHRVSummaryByDateRequest,
+    options: TokenRequestOptions,
+  ): Promise<HRVResponse> {
+    return HRVResponseFromJson(
+      await this.getHRVSummaryByDateRaw(request, options),
+    );
+  }
+
+  async getHRVSummaryByDateRaw(
+    request: GetHRVSummaryByDateRequest,
+    options: TokenRequestOptions,
+  ): Promise<unknown> {
+    const { localDate } = request;
+    validateDateString(localDate);
+    const path = `/1/user/-/hrv/date/${localDate}.json`;
+    return this.get(path, options);
+  }
+
+  async getHRVIntradayByDate(
+    request: GetHRVIntradayRequest,
+    options: TokenRequestOptions,
+  ): Promise<HRVResponse> {
+    return HRVResponseFromJson(
+      await this.getHRVIntradayByDateRaw(request, options),
+    );
+  }
+
+  async getHRVIntradayByDateRaw(
+    request: GetHRVIntradayRequest,
+    options: TokenRequestOptions,
+  ): Promise<unknown> {
+    const { localDate } = request;
+    validateDateString(localDate);
+    const path = `/1/user/-/hrv/${localDate}/all.json`;
     return this.get(path, options);
   }
 }

--- a/src/apis/heart-rate.api.ts
+++ b/src/apis/heart-rate.api.ts
@@ -95,13 +95,16 @@ export class HeartRateApi extends BaseApi {
   /**
    * https://dev.fitbit.com/build/reference/web-api/intraday/get-hrv-intraday-by-date/
    * @param request
+   * @param offsetFromUTCMillis
    * @param options
    */
   async getHRVIntradayByDate(
     request: GetHRVIntradayRequest,
+    offsetFromUTCMillis: number,
     options: TokenRequestOptions,
   ): Promise<HRVIntradayResponse> {
     return HRVIntradayResponseFromJson(
+      offsetFromUTCMillis,
       await this.getHRVIntradayByDateRaw(request, options),
     );
   }

--- a/src/apis/heart-rate.api.ts
+++ b/src/apis/heart-rate.api.ts
@@ -3,8 +3,10 @@ import { DetailLevel } from '../types';
 import {
   HeartRateResponse,
   HeartRateResponseFromJson,
-  HRVResponse,
-  HRVResponseFromJson,
+  HRVIntradayResponse,
+  HRVIntradayResponseFromJson,
+  HRVSummaryResponse,
+  HRVSummaryResponseFromJson,
 } from '../models';
 import { validateDateString } from '../utils/date.utils';
 
@@ -69,8 +71,8 @@ export class HeartRateApi extends BaseApi {
   async getHRVSummaryByDate(
     request: GetHRVSummaryByDateRequest,
     options: TokenRequestOptions,
-  ): Promise<HRVResponse> {
-    return HRVResponseFromJson(
+  ): Promise<HRVSummaryResponse> {
+    return HRVSummaryResponseFromJson(
       await this.getHRVSummaryByDateRaw(request, options),
     );
   }
@@ -88,8 +90,8 @@ export class HeartRateApi extends BaseApi {
   async getHRVIntradayByDate(
     request: GetHRVIntradayRequest,
     options: TokenRequestOptions,
-  ): Promise<HRVResponse> {
-    return HRVResponseFromJson(
+  ): Promise<HRVIntradayResponse> {
+    return HRVIntradayResponseFromJson(
       await this.getHRVIntradayByDateRaw(request, options),
     );
   }

--- a/src/fitbit-client.ts
+++ b/src/fitbit-client.ts
@@ -1,6 +1,8 @@
 import {
   AuthToken,
   HeartRateResponse,
+  HRVIntradayResponse,
+  HRVSummaryResponse,
   OAuthSession,
   PartialAuthToken,
   SleepResponse,
@@ -67,6 +69,10 @@ export class FitbitClient {
     this.heartRate = {
       getHeartRateIntraday: this.getHeartRateIntraday.bind(this),
       getHeartRateIntradayRaw: this.getHeartRateIntradayRaw.bind(this),
+      getHRVSummary: this.getHRVSummary.bind(this),
+      getHRVSummaryRaw: this.getHRVSummaryRaw.bind(this),
+      getHRVIntraday: this.getHRVIntraday.bind(this),
+      getHRVIntradayRaw: this.getHRVIntradayRaw.bind(this),
     };
     this.activity = {
       getStepsIntraday: this.getStepsIntraday.bind(this),
@@ -131,6 +137,10 @@ export class FitbitClient {
       localDate: string,
       detailLevel: DetailLevel,
     ) => Promise<unknown>;
+    getHRVSummary: (localDate: string) => Promise<HRVSummaryResponse>;
+    getHRVSummaryRaw: (localDate: string) => Promise<unknown>;
+    getHRVIntraday: (localDate: string) => Promise<HRVIntradayResponse>;
+    getHRVIntradayRaw: (localDate: string) => Promise<unknown>;
   };
 
   public activity: {
@@ -362,6 +372,48 @@ export class FitbitClient {
       {
         localDate,
         detailLevel,
+      },
+      { accessToken },
+    );
+  }
+
+  private async getHRVSummary(localDate: string): Promise<HRVSummaryResponse> {
+    const accessToken = await this.auth.getAccessToken();
+    return await heartRateApi.getHRVSummaryByDate(
+      {
+        localDate,
+      },
+      { accessToken },
+    );
+  }
+
+  private async getHRVSummaryRaw(localDate: string): Promise<unknown> {
+    const accessToken = await this.auth.getAccessToken();
+    return await heartRateApi.getHRVSummaryByDateRaw(
+      {
+        localDate,
+      },
+      { accessToken },
+    );
+  }
+
+  private async getHRVIntraday(
+    localDate: string,
+  ): Promise<HRVIntradayResponse> {
+    const accessToken = await this.auth.getAccessToken();
+    return await heartRateApi.getHRVIntradayByDate(
+      {
+        localDate,
+      },
+      { accessToken },
+    );
+  }
+
+  private async getHRVIntradayRaw(localDate: string): Promise<unknown> {
+    const accessToken = await this.auth.getAccessToken();
+    return await heartRateApi.getHRVIntradayByDateRaw(
+      {
+        localDate,
       },
       { accessToken },
     );

--- a/src/fitbit-client.ts
+++ b/src/fitbit-client.ts
@@ -139,7 +139,10 @@ export class FitbitClient {
     ) => Promise<unknown>;
     getHRVSummary: (localDate: string) => Promise<HRVSummaryResponse>;
     getHRVSummaryRaw: (localDate: string) => Promise<unknown>;
-    getHRVIntraday: (localDate: string) => Promise<HRVIntradayResponse>;
+    getHRVIntraday: (
+      localDate: string,
+      offsetFromUTCMillis: number,
+    ) => Promise<HRVIntradayResponse>;
     getHRVIntradayRaw: (localDate: string) => Promise<unknown>;
   };
 
@@ -399,12 +402,14 @@ export class FitbitClient {
 
   private async getHRVIntraday(
     localDate: string,
+    offsetFromUTCMillis: number,
   ): Promise<HRVIntradayResponse> {
     const accessToken = await this.auth.getAccessToken();
     return await heartRateApi.getHRVIntradayByDate(
       {
         localDate,
       },
+      offsetFromUTCMillis,
       { accessToken },
     );
   }

--- a/src/models/hrv-intraday.spec.ts
+++ b/src/models/hrv-intraday.spec.ts
@@ -2,6 +2,7 @@ import { HRVIntradayResponseFromJson } from './hrv-intraday';
 
 describe('HRVIntraday', () => {
   it('問題なく型変換出来ること', () => {
+    const offsetFromUTCMillis = 9 * 60 * 60 * 1000; // JST (UTC+9)
     const json = {
       hrv: [
         {
@@ -30,13 +31,16 @@ describe('HRVIntraday', () => {
       ],
     };
 
-    const hrvIntradayResponse = HRVIntradayResponseFromJson(json);
+    const hrvIntradayResponse = HRVIntradayResponseFromJson(
+      offsetFromUTCMillis,
+      json,
+    );
     expect(hrvIntradayResponse.hRVIntraday).toBeDefined();
     expect(hrvIntradayResponse.hRVIntraday.length).toEqual(1);
     expect(hrvIntradayResponse.hRVIntraday[0].localDate).toEqual('2024-10-07');
     expect(hrvIntradayResponse.hRVIntraday[0].minutes.length).toEqual(2);
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[0].minute).toEqual(
-      '2024-10-07T05:07:30.000',
+      new Date('2024-10-07T14:07:30.000+09:00'),
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[0].value.rmssd).toEqual(
       45.5,
@@ -51,7 +55,7 @@ describe('HRVIntraday', () => {
       0.15,
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[1].minute).toEqual(
-      '2024-10-07T05:12:30.000',
+      new Date('2024-10-07T14:12:30.000+09:00'),
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[1].value.rmssd).toEqual(
       48.2,
@@ -68,13 +72,18 @@ describe('HRVIntraday', () => {
   });
 
   it('hrvフィールドがない場合でも問題なく型変換出来ること', () => {
+    const offsetFromUTCMillis = 9 * 60 * 60 * 1000;
     const json = {};
 
-    const hrvIntradayResponse = HRVIntradayResponseFromJson(json);
+    const hrvIntradayResponse = HRVIntradayResponseFromJson(
+      offsetFromUTCMillis,
+      json,
+    );
     expect(hrvIntradayResponse.hRVIntraday.length).toEqual(0);
   });
 
   it('複数のminutesがある場合でも問題なく型変換出来ること', () => {
+    const offsetFromUTCMillis = 9 * 60 * 60 * 1000;
     const json = {
       hrv: [
         {
@@ -112,7 +121,10 @@ describe('HRVIntraday', () => {
       ],
     };
 
-    const hrvIntradayResponse = HRVIntradayResponseFromJson(json);
+    const hrvIntradayResponse = HRVIntradayResponseFromJson(
+      offsetFromUTCMillis,
+      json,
+    );
     expect(hrvIntradayResponse.hRVIntraday).toBeDefined();
     expect(hrvIntradayResponse.hRVIntraday.length).toEqual(1);
     expect(hrvIntradayResponse.hRVIntraday[0].localDate).toEqual('2024-10-07');

--- a/src/models/hrv-intraday.spec.ts
+++ b/src/models/hrv-intraday.spec.ts
@@ -6,7 +6,7 @@ describe('HRVIntraday', () => {
     const json = {
       hrv: [
         {
-          localDate: '2024-10-07',
+          dateTime: '2024-10-07',
           minutes: [
             {
               minute: '2024-10-07T05:07:30.000',
@@ -87,7 +87,7 @@ describe('HRVIntraday', () => {
     const json = {
       hrv: [
         {
-          localDate: '2024-10-07',
+          dateTime: '2024-10-07',
           minutes: [
             {
               minute: '2024-10-07T05:07:30.000',
@@ -182,7 +182,7 @@ describe('HRVIntraday', () => {
     const fitbitJson = {
       hrv: [
         {
-          localDate: '2025-10-14',
+          dateTime: '2025-10-14',
           minutes: [
             {
               minute: '2025-10-14T02:25:00.000',

--- a/src/models/hrv-intraday.spec.ts
+++ b/src/models/hrv-intraday.spec.ts
@@ -655,12 +655,29 @@ describe('HRVIntraday', () => {
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[0].value.rmssd).toEqual(
       71.841,
     );
-
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[0].value.coverage,
+    ).toEqual(0.864);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[0].value.hf).toEqual(
+      512.47,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[0].value.lf).toEqual(
+      3213.718,
+    );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[1].minute).toEqual(
       new Date('2025-10-14T02:30:00.000+09:00'),
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[1].value.rmssd).toEqual(
       75.641,
+    );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[1].value.coverage,
+    ).toEqual(0.921);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[1].value.hf).toEqual(
+      963.91,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[1].value.lf).toEqual(
+      2509.695,
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[2].minute).toEqual(
       new Date('2025-10-14T02:35:00.000+09:00'),
@@ -668,11 +685,29 @@ describe('HRVIntraday', () => {
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[2].value.rmssd).toEqual(
       79.315,
     );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[2].value.coverage,
+    ).toEqual(0.975);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[2].value.hf).toEqual(
+      930.394,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[2].value.lf).toEqual(
+      833.697,
+    );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[3].minute).toEqual(
       new Date('2025-10-14T02:40:00.000+09:00'),
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[3].value.rmssd).toEqual(
       83.103,
+    );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[3].value.coverage,
+    ).toEqual(0.927);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[3].value.hf).toEqual(
+      1208.774,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[3].value.lf).toEqual(
+      1836.921,
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[4].minute).toEqual(
       new Date('2025-10-14T03:00:00.000+09:00'),
@@ -680,11 +715,29 @@ describe('HRVIntraday', () => {
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[4].value.rmssd).toEqual(
       77.341,
     );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[4].value.coverage,
+    ).toEqual(0.886);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[4].value.hf).toEqual(
+      1210.176,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[4].value.lf).toEqual(
+      744.785,
+    );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[5].minute).toEqual(
       new Date('2025-10-14T03:05:00.000+09:00'),
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[5].value.rmssd).toEqual(
       45.338,
+    );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[5].value.coverage,
+    ).toEqual(0.884);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[5].value.hf).toEqual(
+      351.841,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[5].value.lf).toEqual(
+      524.131,
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[6].minute).toEqual(
       new Date('2025-10-14T03:10:00.000+09:00'),
@@ -692,11 +745,29 @@ describe('HRVIntraday', () => {
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[6].value.rmssd).toEqual(
       63.953,
     );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[6].value.coverage,
+    ).toEqual(0.814);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[6].value.hf).toEqual(
+      1030.81,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[6].value.lf).toEqual(
+      1277.989,
+    );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[7].minute).toEqual(
       new Date('2025-10-14T03:20:00.000+09:00'),
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[7].value.rmssd).toEqual(
       74.139,
+    );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[7].value.coverage,
+    ).toEqual(0.933);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[7].value.hf).toEqual(
+      798.525,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[7].value.lf).toEqual(
+      1184.857,
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[8].minute).toEqual(
       new Date('2025-10-14T03:25:00.000+09:00'),
@@ -704,11 +775,29 @@ describe('HRVIntraday', () => {
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[8].value.rmssd).toEqual(
       29.505,
     );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[8].value.coverage,
+    ).toEqual(0.927);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[8].value.hf).toEqual(
+      297.017,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[8].value.lf).toEqual(
+      1175.56,
+    );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[9].minute).toEqual(
       new Date('2025-10-14T03:40:00.000+09:00'),
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[9].value.rmssd).toEqual(
       74.782,
+    );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[9].value.coverage,
+    ).toEqual(0.914);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[9].value.hf).toEqual(
+      705.827,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[9].value.lf).toEqual(
+      1793.416,
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[10].minute).toEqual(
       new Date('2025-10-14T03:45:00.000+09:00'),
@@ -716,11 +805,29 @@ describe('HRVIntraday', () => {
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[10].value.rmssd).toEqual(
       71.871,
     );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[10].value.coverage,
+    ).toEqual(0.936);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[10].value.hf).toEqual(
+      969.725,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[10].value.lf).toEqual(
+      471.999,
+    );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[11].minute).toEqual(
       new Date('2025-10-14T03:50:00.000+09:00'),
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[11].value.rmssd).toEqual(
       90.507,
+    );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[11].value.coverage,
+    ).toEqual(1.002);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[11].value.hf).toEqual(
+      1338.95,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[11].value.lf).toEqual(
+      757.661,
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[12].minute).toEqual(
       new Date('2025-10-14T04:00:00.000+09:00'),
@@ -728,11 +835,29 @@ describe('HRVIntraday', () => {
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[12].value.rmssd).toEqual(
       128.997,
     );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[12].value.coverage,
+    ).toEqual(0.946);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[12].value.hf).toEqual(
+      2488.285,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[12].value.lf).toEqual(
+      829.574,
+    );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[13].minute).toEqual(
       new Date('2025-10-14T04:20:00.000+09:00'),
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[13].value.rmssd).toEqual(
       105.231,
+    );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[13].value.coverage,
+    ).toEqual(0.942);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[13].value.hf).toEqual(
+      1501.178,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[13].value.lf).toEqual(
+      331.256,
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[14].minute).toEqual(
       new Date('2025-10-14T04:25:00.000+09:00'),
@@ -740,11 +865,29 @@ describe('HRVIntraday', () => {
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[14].value.rmssd).toEqual(
       108.002,
     );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[14].value.coverage,
+    ).toEqual(0.873);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[14].value.hf).toEqual(
+      1577.863,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[14].value.lf).toEqual(
+      1426.896,
+    );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[15].minute).toEqual(
       new Date('2025-10-14T04:30:00.000+09:00'),
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[15].value.rmssd).toEqual(
       86.191,
+    );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[15].value.coverage,
+    ).toEqual(1.004);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[15].value.hf).toEqual(
+      1206.419,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[15].value.lf).toEqual(
+      482.541,
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[16].minute).toEqual(
       new Date('2025-10-14T04:35:00.000+09:00'),
@@ -752,11 +895,29 @@ describe('HRVIntraday', () => {
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[16].value.rmssd).toEqual(
       86.051,
     );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[16].value.coverage,
+    ).toEqual(1.001);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[16].value.hf).toEqual(
+      1432.504,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[16].value.lf).toEqual(
+      413.246,
+    );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[17].minute).toEqual(
       new Date('2025-10-14T04:40:00.000+09:00'),
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[17].value.rmssd).toEqual(
       76.834,
+    );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[17].value.coverage,
+    ).toEqual(1.005);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[17].value.hf).toEqual(
+      1134.286,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[17].value.lf).toEqual(
+      388.081,
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[18].minute).toEqual(
       new Date('2025-10-14T04:45:00.000+09:00'),
@@ -764,11 +925,29 @@ describe('HRVIntraday', () => {
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[18].value.rmssd).toEqual(
       77.561,
     );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[18].value.coverage,
+    ).toEqual(1.005);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[18].value.hf).toEqual(
+      1273.712,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[18].value.lf).toEqual(
+      281.468,
+    );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[19].minute).toEqual(
       new Date('2025-10-14T04:50:00.000+09:00'),
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[19].value.rmssd).toEqual(
       84.567,
+    );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[19].value.coverage,
+    ).toEqual(1.001);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[19].value.hf).toEqual(
+      1020.75,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[19].value.lf).toEqual(
+      2466.274,
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[20].minute).toEqual(
       new Date('2025-10-14T04:55:00.000+09:00'),
@@ -776,11 +955,29 @@ describe('HRVIntraday', () => {
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[20].value.rmssd).toEqual(
       74.39,
     );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[20].value.coverage,
+    ).toEqual(1.005);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[20].value.hf).toEqual(
+      1142.572,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[20].value.lf).toEqual(
+      166.714,
+    );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[21].minute).toEqual(
       new Date('2025-10-14T05:00:00.000+09:00'),
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[21].value.rmssd).toEqual(
       73.117,
+    );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[21].value.coverage,
+    ).toEqual(0.873);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[21].value.hf).toEqual(
+      1129.713,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[21].value.lf).toEqual(
+      357.414,
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[22].minute).toEqual(
       new Date('2025-10-14T05:05:00.000+09:00'),
@@ -788,11 +985,29 @@ describe('HRVIntraday', () => {
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[22].value.rmssd).toEqual(
       77.315,
     );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[22].value.coverage,
+    ).toEqual(0.769);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[22].value.hf).toEqual(
+      949.197,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[22].value.lf).toEqual(
+      1287.311,
+    );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[23].minute).toEqual(
       new Date('2025-10-14T05:10:00.000+09:00'),
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[23].value.rmssd).toEqual(
       89.261,
+    );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[23].value.coverage,
+    ).toEqual(0.715);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[23].value.hf).toEqual(
+      1756.907,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[23].value.lf).toEqual(
+      3544.92,
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[24].minute).toEqual(
       new Date('2025-10-14T05:30:00.000+09:00'),
@@ -800,11 +1015,29 @@ describe('HRVIntraday', () => {
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[24].value.rmssd).toEqual(
       75.464,
     );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[24].value.coverage,
+    ).toEqual(0.79);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[24].value.hf).toEqual(
+      1268.478,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[24].value.lf).toEqual(
+      1082.202,
+    );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[25].minute).toEqual(
       new Date('2025-10-14T05:35:00.000+09:00'),
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[25].value.rmssd).toEqual(
       80.607,
+    );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[25].value.coverage,
+    ).toEqual(0.729);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[25].value.hf).toEqual(
+      946.016,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[25].value.lf).toEqual(
+      2790.421,
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[26].minute).toEqual(
       new Date('2025-10-14T05:40:00.000+09:00'),
@@ -812,11 +1045,29 @@ describe('HRVIntraday', () => {
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[26].value.rmssd).toEqual(
       100.47,
     );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[26].value.coverage,
+    ).toEqual(0.779);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[26].value.hf).toEqual(
+      1601.679,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[26].value.lf).toEqual(
+      2930.757,
+    );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[27].minute).toEqual(
       new Date('2025-10-14T05:50:00.000+09:00'),
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[27].value.rmssd).toEqual(
       85.194,
+    );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[27].value.coverage,
+    ).toEqual(0.968);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[27].value.hf).toEqual(
+      1320.485,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[27].value.lf).toEqual(
+      5866.716,
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[28].minute).toEqual(
       new Date('2025-10-14T05:55:00.000+09:00'),
@@ -824,11 +1075,29 @@ describe('HRVIntraday', () => {
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[28].value.rmssd).toEqual(
       53.26,
     );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[28].value.coverage,
+    ).toEqual(0.777);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[28].value.hf).toEqual(
+      620.894,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[28].value.lf).toEqual(
+      4851.49,
+    );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[29].minute).toEqual(
       new Date('2025-10-14T06:00:00.000+09:00'),
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[29].value.rmssd).toEqual(
       65.87,
+    );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[29].value.coverage,
+    ).toEqual(0.906);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[29].value.hf).toEqual(
+      650.705,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[29].value.lf).toEqual(
+      2672.076,
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[30].minute).toEqual(
       new Date('2025-10-14T06:05:00.000+09:00'),
@@ -836,11 +1105,29 @@ describe('HRVIntraday', () => {
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[30].value.rmssd).toEqual(
       79.297,
     );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[30].value.coverage,
+    ).toEqual(0.982);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[30].value.hf).toEqual(
+      1174.452,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[30].value.lf).toEqual(
+      2733.738,
+    );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[31].minute).toEqual(
       new Date('2025-10-14T06:10:00.000+09:00'),
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[31].value.rmssd).toEqual(
       85.332,
+    );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[31].value.coverage,
+    ).toEqual(0.947);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[31].value.hf).toEqual(
+      1247.196,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[31].value.lf).toEqual(
+      6607.423,
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[32].minute).toEqual(
       new Date('2025-10-14T06:15:00.000+09:00'),
@@ -848,11 +1135,29 @@ describe('HRVIntraday', () => {
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[32].value.rmssd).toEqual(
       73.544,
     );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[32].value.coverage,
+    ).toEqual(0.795);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[32].value.hf).toEqual(
+      813.578,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[32].value.lf).toEqual(
+      6011.86,
+    );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[33].minute).toEqual(
       new Date('2025-10-14T06:20:00.000+09:00'),
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[33].value.rmssd).toEqual(
       64.704,
+    );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[33].value.coverage,
+    ).toEqual(0.819);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[33].value.hf).toEqual(
+      1010.555,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[33].value.lf).toEqual(
+      2084.832,
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[34].minute).toEqual(
       new Date('2025-10-14T06:25:00.000+09:00'),
@@ -860,11 +1165,29 @@ describe('HRVIntraday', () => {
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[34].value.rmssd).toEqual(
       37.107,
     );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[34].value.coverage,
+    ).toEqual(1.003);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[34].value.hf).toEqual(
+      239.076,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[34].value.lf).toEqual(
+      956.103,
+    );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[35].minute).toEqual(
       new Date('2025-10-14T06:30:00.000+09:00'),
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[35].value.rmssd).toEqual(
       22.198,
+    );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[35].value.coverage,
+    ).toEqual(0.726);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[35].value.hf).toEqual(
+      117.927,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[35].value.lf).toEqual(
+      539.171,
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[36].minute).toEqual(
       new Date('2025-10-14T07:30:00.000+09:00'),
@@ -872,11 +1195,29 @@ describe('HRVIntraday', () => {
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[36].value.rmssd).toEqual(
       90.307,
     );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[36].value.coverage,
+    ).toEqual(0.851);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[36].value.hf).toEqual(
+      1383.067,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[36].value.lf).toEqual(
+      9080.806,
+    );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[37].minute).toEqual(
       new Date('2025-10-14T07:35:00.000+09:00'),
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[37].value.rmssd).toEqual(
       87.027,
+    );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[37].value.coverage,
+    ).toEqual(0.983);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[37].value.hf).toEqual(
+      1650.812,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[37].value.lf).toEqual(
+      1554.714,
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[38].minute).toEqual(
       new Date('2025-10-14T07:40:00.000+09:00'),
@@ -884,11 +1225,29 @@ describe('HRVIntraday', () => {
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[38].value.rmssd).toEqual(
       82.524,
     );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[38].value.coverage,
+    ).toEqual(0.938);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[38].value.hf).toEqual(
+      1310.99,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[38].value.lf).toEqual(
+      2339.539,
+    );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[39].minute).toEqual(
       new Date('2025-10-14T07:45:00.000+09:00'),
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[39].value.rmssd).toEqual(
       74.364,
+    );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[39].value.coverage,
+    ).toEqual(1.005);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[39].value.hf).toEqual(
+      1216.019,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[39].value.lf).toEqual(
+      1202.025,
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[40].minute).toEqual(
       new Date('2025-10-14T07:50:00.000+09:00'),
@@ -896,11 +1255,29 @@ describe('HRVIntraday', () => {
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[40].value.rmssd).toEqual(
       87.109,
     );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[40].value.coverage,
+    ).toEqual(0.955);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[40].value.hf).toEqual(
+      1284.971,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[40].value.lf).toEqual(
+      2648.302,
+    );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[41].minute).toEqual(
       new Date('2025-10-14T07:55:00.000+09:00'),
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[41].value.rmssd).toEqual(
       75.911,
+    );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[41].value.coverage,
+    ).toEqual(0.913);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[41].value.hf).toEqual(
+      1388.851,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[41].value.lf).toEqual(
+      2662.252,
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[42].minute).toEqual(
       new Date('2025-10-14T08:00:00.000+09:00'),
@@ -908,11 +1285,29 @@ describe('HRVIntraday', () => {
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[42].value.rmssd).toEqual(
       62.548,
     );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[42].value.coverage,
+    ).toEqual(1.003);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[42].value.hf).toEqual(
+      1320.046,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[42].value.lf).toEqual(
+      342.554,
+    );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[43].minute).toEqual(
       new Date('2025-10-14T08:05:00.000+09:00'),
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[43].value.rmssd).toEqual(
       66.518,
+    );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[43].value.coverage,
+    ).toEqual(0.824);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[43].value.hf).toEqual(
+      1317.98,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[43].value.lf).toEqual(
+      367.929,
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[44].minute).toEqual(
       new Date('2025-10-14T08:10:00.000+09:00'),
@@ -920,11 +1315,29 @@ describe('HRVIntraday', () => {
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[44].value.rmssd).toEqual(
       70.275,
     );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[44].value.coverage,
+    ).toEqual(0.9);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[44].value.hf).toEqual(
+      1193.324,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[44].value.lf).toEqual(
+      2493.988,
+    );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[45].minute).toEqual(
       new Date('2025-10-14T08:30:00.000+09:00'),
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[45].value.rmssd).toEqual(
       67.2,
+    );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[45].value.coverage,
+    ).toEqual(0.918);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[45].value.hf).toEqual(
+      744.026,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[45].value.lf).toEqual(
+      2171.039,
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[46].minute).toEqual(
       new Date('2025-10-14T08:35:00.000+09:00'),
@@ -932,11 +1345,29 @@ describe('HRVIntraday', () => {
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[46].value.rmssd).toEqual(
       67.444,
     );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[46].value.coverage,
+    ).toEqual(0.939);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[46].value.hf).toEqual(
+      911.145,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[46].value.lf).toEqual(
+      4310.475,
+    );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[47].minute).toEqual(
       new Date('2025-10-14T08:40:00.000+09:00'),
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[47].value.rmssd).toEqual(
       69.976,
+    );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[47].value.coverage,
+    ).toEqual(0.989);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[47].value.hf).toEqual(
+      1457.141,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[47].value.lf).toEqual(
+      1684.807,
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[48].minute).toEqual(
       new Date('2025-10-14T08:45:00.000+09:00'),
@@ -944,11 +1375,29 @@ describe('HRVIntraday', () => {
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[48].value.rmssd).toEqual(
       67.085,
     );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[48].value.coverage,
+    ).toEqual(0.991);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[48].value.hf).toEqual(
+      1168.868,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[48].value.lf).toEqual(
+      622.291,
+    );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[49].minute).toEqual(
       new Date('2025-10-14T08:50:00.000+09:00'),
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[49].value.rmssd).toEqual(
       67.336,
+    );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[49].value.coverage,
+    ).toEqual(0.929);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[49].value.hf).toEqual(
+      786.823,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[49].value.lf).toEqual(
+      3916.351,
     );
   });
 });

--- a/src/models/hrv-intraday.spec.ts
+++ b/src/models/hrv-intraday.spec.ts
@@ -18,7 +18,7 @@ describe('HRVIntraday', () => {
               },
             },
             {
-              minute: '2024-10-07T05:12:30.000',
+              minute: '2024-10-07T14:12:30.000',
               value: {
                 rmssd: 48.2,
                 coverage: 0.92,
@@ -40,7 +40,7 @@ describe('HRVIntraday', () => {
     expect(hrvIntradayResponse.hRVIntraday[0].localDate).toEqual('2024-10-07');
     expect(hrvIntradayResponse.hRVIntraday[0].minutes.length).toEqual(2);
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[0].minute).toEqual(
-      new Date('2024-10-07T14:07:30.000+09:00'),
+      new Date('2024-10-06T20:07:30.000Z'),
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[0].value.rmssd).toEqual(
       45.5,
@@ -55,7 +55,7 @@ describe('HRVIntraday', () => {
       0.15,
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[1].minute).toEqual(
-      new Date('2024-10-07T14:12:30.000+09:00'),
+      new Date('2024-10-07T05:12:30.000Z'),
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[1].value.rmssd).toEqual(
       48.2,
@@ -129,14 +129,50 @@ describe('HRVIntraday', () => {
     expect(hrvIntradayResponse.hRVIntraday.length).toEqual(1);
     expect(hrvIntradayResponse.hRVIntraday[0].localDate).toEqual('2024-10-07');
     expect(hrvIntradayResponse.hRVIntraday[0].minutes.length).toEqual(3);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[0].minute).toEqual(
+      new Date('2024-10-06T20:07:30.000Z'),
+    );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[0].value.rmssd).toEqual(
       45.5,
+    );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[0].value.coverage,
+    ).toEqual(0.95);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[0].value.hf).toEqual(
+      0.25,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[0].value.lf).toEqual(
+      0.15,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[1].minute).toEqual(
+      new Date('2024-10-06T20:12:30.000Z'),
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[1].value.rmssd).toEqual(
       46.8,
     );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[1].value.coverage,
+    ).toEqual(0.93);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[1].value.hf).toEqual(
+      0.26,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[1].value.lf).toEqual(
+      0.16,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[2].minute).toEqual(
+      new Date('2024-10-06T20:17:30.000Z'),
+    );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[2].value.rmssd).toEqual(
       47.2,
+    );
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[2].value.coverage,
+    ).toEqual(0.94);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[2].value.hf).toEqual(
+      0.27,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[2].value.lf).toEqual(
+      0.17,
     );
   });
 });

--- a/src/models/hrv-intraday.spec.ts
+++ b/src/models/hrv-intraday.spec.ts
@@ -1,0 +1,177 @@
+import { HRVIntradayResponseFromJson } from './hrv-intraday';
+
+describe('HRVIntraday', () => {
+  it('問題なく型変換出来ること', () => {
+    const json = {
+      hrv: [
+        {
+          dateTime: '2024-10-07',
+          minutes: [
+            {
+              minute: new Date('2024-10-07T05:07:30.000+09:00'),
+              value: [
+                {
+                  rmssd: 45.5,
+                  coverage: 0.95,
+                  hf: 0.25,
+                  lf: 0.15,
+                },
+              ],
+            },
+            {
+              minute: new Date('2024-10-07T05:12:30.000+09:00'),
+              value: [
+                {
+                  rmssd: 48.2,
+                  coverage: 0.92,
+                  hf: 0.28,
+                  lf: 0.18,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      'hrv-intraday': {
+        hrv: [
+          {
+            dateTime: '2024-10-07',
+            minutes: [
+              {
+                minute: new Date('2024-10-07T05:07:30.000+09:00'),
+                value: [
+                  {
+                    rmssd: 45.5,
+                    coverage: 0.95,
+                    hf: 0.25,
+                    lf: 0.15,
+                  },
+                ],
+              },
+              {
+                minute: new Date('2024-10-07T05:12:30.000+09:00'),
+                value: [
+                  {
+                    rmssd: 48.2,
+                    coverage: 0.92,
+                    hf: 0.28,
+                    lf: 0.18,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    const hrvIntradayResponse = HRVIntradayResponseFromJson(json);
+    expect(hrvIntradayResponse.hRVIntraday).toBeDefined();
+    expect(hrvIntradayResponse.hRVIntraday?.hRvIntraday.length).toEqual(1);
+    expect(hrvIntradayResponse.hRVIntraday?.hRvIntraday[0].localDate).toEqual(
+      '2024-10-07',
+    );
+    expect(
+      hrvIntradayResponse.hRVIntraday?.hRvIntraday[0].minutes.length,
+    ).toEqual(2);
+    expect(
+      hrvIntradayResponse.hRVIntraday?.hRvIntraday[0].minutes[0].minute,
+    ).toEqual(new Date('2024-10-07T05:07:30.000+09:00'));
+    expect(
+      hrvIntradayResponse.hRVIntraday?.hRvIntraday[0].minutes[0].value.length,
+    ).toEqual(1);
+    expect(
+      hrvIntradayResponse.hRVIntraday?.hRvIntraday[0].minutes[0].value[0].rmssd,
+    ).toEqual(45.5);
+    expect(
+      hrvIntradayResponse.hRVIntraday?.hRvIntraday[0].minutes[0].value[0]
+        .coverage,
+    ).toEqual(0.95);
+    expect(
+      hrvIntradayResponse.hRVIntraday?.hRvIntraday[0].minutes[0].value[0].hf,
+    ).toEqual(0.25);
+    expect(
+      hrvIntradayResponse.hRVIntraday?.hRvIntraday[0].minutes[0].value[0].lf,
+    ).toEqual(0.15);
+    expect(
+      hrvIntradayResponse.hRVIntraday?.hRvIntraday[0].minutes[1].minute,
+    ).toEqual(new Date('2024-10-07T05:12:30.000+09:00'));
+    expect(
+      hrvIntradayResponse.hRVIntraday?.hRvIntraday[0].minutes[1].value[0].rmssd,
+    ).toEqual(48.2);
+  });
+
+  it('hrvフィールドがない場合でも問題なく型変換出来ること', () => {
+    const json = {};
+
+    const hrvIntradayResponse = HRVIntradayResponseFromJson(json);
+    expect(hrvIntradayResponse.hRVIntraday).toBeUndefined();
+  });
+
+  it('複数のvalueがある場合でも問題なく型変換出来ること', () => {
+    const json = {
+      hrv: [
+        {
+          dateTime: '2024-10-07',
+          minutes: [
+            {
+              minute: new Date('2024-10-07T05:07:30.000+09:00'),
+              value: [
+                {
+                  rmssd: 45.5,
+                  coverage: 0.95,
+                  hf: 0.25,
+                  lf: 0.15,
+                },
+                {
+                  rmssd: 46.8,
+                  coverage: 0.93,
+                  hf: 0.26,
+                  lf: 0.16,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      'hrv-intraday': {
+        hrv: [
+          {
+            dateTime: '2024-10-07',
+            minutes: [
+              {
+                minute: new Date('2024-10-07T05:07:30.000+09:00'),
+                value: [
+                  {
+                    rmssd: 45.5,
+                    coverage: 0.95,
+                    hf: 0.25,
+                    lf: 0.15,
+                  },
+                  {
+                    rmssd: 46.8,
+                    coverage: 0.93,
+                    hf: 0.26,
+                    lf: 0.16,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    const hrvIntradayResponse = HRVIntradayResponseFromJson(json);
+    expect(hrvIntradayResponse.hRVIntraday).toBeDefined();
+    expect(
+      hrvIntradayResponse.hRVIntraday?.hRvIntraday[0].minutes[0].value.length,
+    ).toEqual(2);
+    expect(
+      hrvIntradayResponse.hRVIntraday?.hRvIntraday[0].minutes[0].value[0].rmssd,
+    ).toEqual(45.5);
+    expect(
+      hrvIntradayResponse.hRVIntraday?.hRvIntraday[0].minutes[0].value[1].rmssd,
+    ).toEqual(46.8);
+  });
+});

--- a/src/models/hrv-intraday.spec.ts
+++ b/src/models/hrv-intraday.spec.ts
@@ -40,7 +40,7 @@ describe('HRVIntraday', () => {
     expect(hrvIntradayResponse.hRVIntraday[0].localDate).toEqual('2024-10-07');
     expect(hrvIntradayResponse.hRVIntraday[0].minutes.length).toEqual(2);
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[0].minute).toEqual(
-      new Date('2024-10-06T20:07:30.000Z'),
+      new Date('2024-10-07T05:07:30.000+09:00'),
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[0].value.rmssd).toEqual(
       45.5,
@@ -55,7 +55,7 @@ describe('HRVIntraday', () => {
       0.15,
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[1].minute).toEqual(
-      new Date('2024-10-07T05:12:30.000Z'),
+      new Date('2024-10-07T14:12:30.000+09:00'),
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[1].value.rmssd).toEqual(
       48.2,
@@ -130,7 +130,7 @@ describe('HRVIntraday', () => {
     expect(hrvIntradayResponse.hRVIntraday[0].localDate).toEqual('2024-10-07');
     expect(hrvIntradayResponse.hRVIntraday[0].minutes.length).toEqual(3);
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[0].minute).toEqual(
-      new Date('2024-10-06T20:07:30.000Z'),
+      new Date('2024-10-07T05:07:30.000+09:00'),
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[0].value.rmssd).toEqual(
       45.5,
@@ -145,7 +145,7 @@ describe('HRVIntraday', () => {
       0.15,
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[1].minute).toEqual(
-      new Date('2024-10-06T20:12:30.000Z'),
+      new Date('2024-10-07T05:12:30.000+09:00'),
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[1].value.rmssd).toEqual(
       46.8,
@@ -160,7 +160,7 @@ describe('HRVIntraday', () => {
       0.16,
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[2].minute).toEqual(
-      new Date('2024-10-06T20:17:30.000Z'),
+      new Date('2024-10-07T05:17:30.000+09:00'),
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[2].value.rmssd).toEqual(
       47.2,
@@ -173,6 +173,531 @@ describe('HRVIntraday', () => {
     );
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[2].value.lf).toEqual(
       0.17,
+    );
+  });
+
+  it('fitbitデータとの比較', () => {
+    const offsetFromUTCMillis = 9 * 60 * 60 * 1000; // JST (UTC+9)
+    // 実データを再現したデータ
+    const fitbitJson = {
+      hrv: [
+        {
+          dateTime: '2025-10-14',
+          minutes: [
+            {
+              minute: '2025-10-14T02:25:00.000',
+              value: { rmssd: 71.841, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T02:30:00.000',
+              value: { rmssd: 75.641, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T02:35:00.000',
+              value: { rmssd: 79.315, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T02:40:00.000',
+              value: { rmssd: 83.103, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T03:00:00.000',
+              value: { rmssd: 77.341, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T03:05:00.000',
+              value: { rmssd: 45.338, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T03:10:00.000',
+              value: { rmssd: 63.953, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T03:20:00.000',
+              value: { rmssd: 74.139, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T03:25:00.000',
+              value: { rmssd: 29.505, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T03:40:00.000',
+              value: { rmssd: 74.782, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T03:45:00.000',
+              value: { rmssd: 71.871, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T03:50:00.000',
+              value: { rmssd: 90.507, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T04:00:00.000',
+              value: { rmssd: 128.997, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T04:20:00.000',
+              value: { rmssd: 105.231, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T04:25:00.000',
+              value: { rmssd: 108.002, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T04:30:00.000',
+              value: { rmssd: 86.191, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T04:35:00.000',
+              value: { rmssd: 86.051, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T04:40:00.000',
+              value: { rmssd: 76.834, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T04:45:00.000',
+              value: { rmssd: 77.561, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T04:50:00.000',
+              value: { rmssd: 84.567, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T04:55:00.000',
+              value: { rmssd: 74.39, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T05:00:00.000',
+              value: { rmssd: 73.117, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T05:05:00.000',
+              value: { rmssd: 77.315, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T05:10:00.000',
+              value: { rmssd: 89.261, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T05:30:00.000',
+              value: { rmssd: 75.464, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T05:35:00.000',
+              value: { rmssd: 80.607, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T05:40:00.000',
+              value: { rmssd: 100.47, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T05:50:00.000',
+              value: { rmssd: 85.194, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T05:55:00.000',
+              value: { rmssd: 53.26, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T06:00:00.000',
+              value: { rmssd: 65.87, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T06:05:00.000',
+              value: { rmssd: 79.297, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T06:10:00.000',
+              value: { rmssd: 85.332, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T06:15:00.000',
+              value: { rmssd: 73.544, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T06:20:00.000',
+              value: { rmssd: 64.704, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T06:25:00.000',
+              value: { rmssd: 37.107, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T06:30:00.000',
+              value: { rmssd: 22.198, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T07:30:00.000',
+              value: { rmssd: 90.307, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T07:35:00.000',
+              value: { rmssd: 87.027, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T07:40:00.000',
+              value: { rmssd: 82.524, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T07:45:00.000',
+              value: { rmssd: 74.364, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T07:50:00.000',
+              value: { rmssd: 87.109, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T07:55:00.000',
+              value: { rmssd: 75.911, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T08:00:00.000',
+              value: { rmssd: 62.548, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T08:05:00.000',
+              value: { rmssd: 66.518, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T08:10:00.000',
+              value: { rmssd: 70.275, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T08:30:00.000',
+              value: { rmssd: 67.2, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T08:35:00.000',
+              value: { rmssd: 67.444, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T08:40:00.000',
+              value: { rmssd: 69.976, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T08:45:00.000',
+              value: { rmssd: 67.085, coverage: 0, hf: 0, lf: 0 },
+            },
+            {
+              minute: '2025-10-14T08:50:00.000',
+              value: { rmssd: 67.336, coverage: 0, hf: 0, lf: 0 },
+            },
+          ],
+        },
+      ],
+    };
+
+    const hrvIntradayResponse = HRVIntradayResponseFromJson(
+      offsetFromUTCMillis,
+      fitbitJson,
+    );
+
+    expect(hrvIntradayResponse.hRVIntraday).toBeDefined();
+    expect(hrvIntradayResponse.hRVIntraday.length).toEqual(1);
+    expect(hrvIntradayResponse.hRVIntraday[0].localDate).toEqual('2025-10-14');
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes.length).toEqual(50);
+
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[0].minute).toEqual(
+      new Date('2025-10-14T02:25:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[0].value.rmssd).toEqual(
+      71.841,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[1].minute).toEqual(
+      new Date('2025-10-14T02:30:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[1].value.rmssd).toEqual(
+      75.641,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[2].minute).toEqual(
+      new Date('2025-10-14T02:35:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[2].value.rmssd).toEqual(
+      79.315,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[3].minute).toEqual(
+      new Date('2025-10-14T02:40:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[3].value.rmssd).toEqual(
+      83.103,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[4].minute).toEqual(
+      new Date('2025-10-14T03:00:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[4].value.rmssd).toEqual(
+      77.341,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[5].minute).toEqual(
+      new Date('2025-10-14T03:05:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[5].value.rmssd).toEqual(
+      45.338,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[6].minute).toEqual(
+      new Date('2025-10-14T03:10:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[6].value.rmssd).toEqual(
+      63.953,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[7].minute).toEqual(
+      new Date('2025-10-14T03:20:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[7].value.rmssd).toEqual(
+      74.139,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[8].minute).toEqual(
+      new Date('2025-10-14T03:25:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[8].value.rmssd).toEqual(
+      29.505,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[9].minute).toEqual(
+      new Date('2025-10-14T03:40:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[9].value.rmssd).toEqual(
+      74.782,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[10].minute).toEqual(
+      new Date('2025-10-14T03:45:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[10].value.rmssd).toEqual(
+      71.871,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[11].minute).toEqual(
+      new Date('2025-10-14T03:50:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[11].value.rmssd).toEqual(
+      90.507,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[12].minute).toEqual(
+      new Date('2025-10-14T04:00:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[12].value.rmssd).toEqual(
+      128.997,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[13].minute).toEqual(
+      new Date('2025-10-14T04:20:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[13].value.rmssd).toEqual(
+      105.231,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[14].minute).toEqual(
+      new Date('2025-10-14T04:25:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[14].value.rmssd).toEqual(
+      108.002,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[15].minute).toEqual(
+      new Date('2025-10-14T04:30:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[15].value.rmssd).toEqual(
+      86.191,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[16].minute).toEqual(
+      new Date('2025-10-14T04:35:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[16].value.rmssd).toEqual(
+      86.051,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[17].minute).toEqual(
+      new Date('2025-10-14T04:40:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[17].value.rmssd).toEqual(
+      76.834,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[18].minute).toEqual(
+      new Date('2025-10-14T04:45:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[18].value.rmssd).toEqual(
+      77.561,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[19].minute).toEqual(
+      new Date('2025-10-14T04:50:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[19].value.rmssd).toEqual(
+      84.567,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[20].minute).toEqual(
+      new Date('2025-10-14T04:55:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[20].value.rmssd).toEqual(
+      74.39,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[21].minute).toEqual(
+      new Date('2025-10-14T05:00:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[21].value.rmssd).toEqual(
+      73.117,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[22].minute).toEqual(
+      new Date('2025-10-14T05:05:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[22].value.rmssd).toEqual(
+      77.315,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[23].minute).toEqual(
+      new Date('2025-10-14T05:10:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[23].value.rmssd).toEqual(
+      89.261,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[24].minute).toEqual(
+      new Date('2025-10-14T05:30:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[24].value.rmssd).toEqual(
+      75.464,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[25].minute).toEqual(
+      new Date('2025-10-14T05:35:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[25].value.rmssd).toEqual(
+      80.607,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[26].minute).toEqual(
+      new Date('2025-10-14T05:40:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[26].value.rmssd).toEqual(
+      100.47,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[27].minute).toEqual(
+      new Date('2025-10-14T05:50:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[27].value.rmssd).toEqual(
+      85.194,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[28].minute).toEqual(
+      new Date('2025-10-14T05:55:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[28].value.rmssd).toEqual(
+      53.26,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[29].minute).toEqual(
+      new Date('2025-10-14T06:00:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[29].value.rmssd).toEqual(
+      65.87,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[30].minute).toEqual(
+      new Date('2025-10-14T06:05:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[30].value.rmssd).toEqual(
+      79.297,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[31].minute).toEqual(
+      new Date('2025-10-14T06:10:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[31].value.rmssd).toEqual(
+      85.332,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[32].minute).toEqual(
+      new Date('2025-10-14T06:15:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[32].value.rmssd).toEqual(
+      73.544,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[33].minute).toEqual(
+      new Date('2025-10-14T06:20:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[33].value.rmssd).toEqual(
+      64.704,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[34].minute).toEqual(
+      new Date('2025-10-14T06:25:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[34].value.rmssd).toEqual(
+      37.107,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[35].minute).toEqual(
+      new Date('2025-10-14T06:30:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[35].value.rmssd).toEqual(
+      22.198,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[36].minute).toEqual(
+      new Date('2025-10-14T07:30:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[36].value.rmssd).toEqual(
+      90.307,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[37].minute).toEqual(
+      new Date('2025-10-14T07:35:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[37].value.rmssd).toEqual(
+      87.027,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[38].minute).toEqual(
+      new Date('2025-10-14T07:40:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[38].value.rmssd).toEqual(
+      82.524,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[39].minute).toEqual(
+      new Date('2025-10-14T07:45:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[39].value.rmssd).toEqual(
+      74.364,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[40].minute).toEqual(
+      new Date('2025-10-14T07:50:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[40].value.rmssd).toEqual(
+      87.109,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[41].minute).toEqual(
+      new Date('2025-10-14T07:55:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[41].value.rmssd).toEqual(
+      75.911,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[42].minute).toEqual(
+      new Date('2025-10-14T08:00:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[42].value.rmssd).toEqual(
+      62.548,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[43].minute).toEqual(
+      new Date('2025-10-14T08:05:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[43].value.rmssd).toEqual(
+      66.518,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[44].minute).toEqual(
+      new Date('2025-10-14T08:10:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[44].value.rmssd).toEqual(
+      70.275,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[45].minute).toEqual(
+      new Date('2025-10-14T08:30:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[45].value.rmssd).toEqual(
+      67.2,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[46].minute).toEqual(
+      new Date('2025-10-14T08:35:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[46].value.rmssd).toEqual(
+      67.444,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[47].minute).toEqual(
+      new Date('2025-10-14T08:40:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[47].value.rmssd).toEqual(
+      69.976,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[48].minute).toEqual(
+      new Date('2025-10-14T08:45:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[48].value.rmssd).toEqual(
+      67.085,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[49].minute).toEqual(
+      new Date('2025-10-14T08:50:00.000+09:00'),
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[49].value.rmssd).toEqual(
+      67.336,
     );
   });
 });

--- a/src/models/hrv-intraday.spec.ts
+++ b/src/models/hrv-intraday.spec.ts
@@ -6,7 +6,7 @@ describe('HRVIntraday', () => {
     const json = {
       hrv: [
         {
-          dateTime: '2024-10-07',
+          localDate: '2024-10-07',
           minutes: [
             {
               minute: '2024-10-07T05:07:30.000',
@@ -87,7 +87,7 @@ describe('HRVIntraday', () => {
     const json = {
       hrv: [
         {
-          dateTime: '2024-10-07',
+          localDate: '2024-10-07',
           minutes: [
             {
               minute: '2024-10-07T05:07:30.000',
@@ -182,7 +182,7 @@ describe('HRVIntraday', () => {
     const fitbitJson = {
       hrv: [
         {
-          dateTime: '2025-10-14',
+          localDate: '2025-10-14',
           minutes: [
             {
               minute: '2025-10-14T02:25:00.000',

--- a/src/models/hrv-intraday.spec.ts
+++ b/src/models/hrv-intraday.spec.ts
@@ -6,60 +6,31 @@ describe('HRVIntraday', () => {
       hrv: [
         {
           dateTime: '2024-10-07',
-          minutes: [
-            {
-              minute: new Date('2024-10-07T05:07:30.000+09:00'),
-              value: [
-                {
-                  rmssd: 45.5,
-                  coverage: 0.95,
-                  hf: 0.25,
-                  lf: 0.15,
-                },
-              ],
-            },
-            {
-              minute: new Date('2024-10-07T05:12:30.000+09:00'),
-              value: [
-                {
-                  rmssd: 48.2,
-                  coverage: 0.92,
-                  hf: 0.28,
-                  lf: 0.18,
-                },
-              ],
-            },
-          ],
+          value: {
+            dailyRmssd: 45.5,
+            deepRmssd: 52.3,
+          },
         },
       ],
       'hrv-intraday': {
-        hrv: [
+        minutes: [
           {
-            dateTime: '2024-10-07',
-            minutes: [
-              {
-                minute: new Date('2024-10-07T05:07:30.000+09:00'),
-                value: [
-                  {
-                    rmssd: 45.5,
-                    coverage: 0.95,
-                    hf: 0.25,
-                    lf: 0.15,
-                  },
-                ],
-              },
-              {
-                minute: new Date('2024-10-07T05:12:30.000+09:00'),
-                value: [
-                  {
-                    rmssd: 48.2,
-                    coverage: 0.92,
-                    hf: 0.28,
-                    lf: 0.18,
-                  },
-                ],
-              },
-            ],
+            minute: '2024-10-07T05:07:30.000',
+            value: {
+              rmssd: 45.5,
+              coverage: 0.95,
+              hf: 0.25,
+              lf: 0.15,
+            },
+          },
+          {
+            minute: '2024-10-07T05:12:30.000',
+            value: {
+              rmssd: 48.2,
+              coverage: 0.92,
+              hf: 0.28,
+              lf: 0.18,
+            },
           },
         ],
       },
@@ -67,38 +38,29 @@ describe('HRVIntraday', () => {
 
     const hrvIntradayResponse = HRVIntradayResponseFromJson(json);
     expect(hrvIntradayResponse.hRVIntraday).toBeDefined();
-    expect(hrvIntradayResponse.hRVIntraday?.hRvIntraday.length).toEqual(1);
-    expect(hrvIntradayResponse.hRVIntraday?.hRvIntraday[0].localDate).toEqual(
-      '2024-10-07',
+    expect(hrvIntradayResponse.hRVIntraday?.minutes.length).toEqual(2);
+    expect(hrvIntradayResponse.hRVIntraday?.minutes[0].minute).toEqual(
+      '2024-10-07T05:07:30.000',
     );
-    expect(
-      hrvIntradayResponse.hRVIntraday?.hRvIntraday[0].minutes.length,
-    ).toEqual(2);
-    expect(
-      hrvIntradayResponse.hRVIntraday?.hRvIntraday[0].minutes[0].minute,
-    ).toEqual(new Date('2024-10-07T05:07:30.000+09:00'));
-    expect(
-      hrvIntradayResponse.hRVIntraday?.hRvIntraday[0].minutes[0].value.length,
-    ).toEqual(1);
-    expect(
-      hrvIntradayResponse.hRVIntraday?.hRvIntraday[0].minutes[0].value[0].rmssd,
-    ).toEqual(45.5);
-    expect(
-      hrvIntradayResponse.hRVIntraday?.hRvIntraday[0].minutes[0].value[0]
-        .coverage,
-    ).toEqual(0.95);
-    expect(
-      hrvIntradayResponse.hRVIntraday?.hRvIntraday[0].minutes[0].value[0].hf,
-    ).toEqual(0.25);
-    expect(
-      hrvIntradayResponse.hRVIntraday?.hRvIntraday[0].minutes[0].value[0].lf,
-    ).toEqual(0.15);
-    expect(
-      hrvIntradayResponse.hRVIntraday?.hRvIntraday[0].minutes[1].minute,
-    ).toEqual(new Date('2024-10-07T05:12:30.000+09:00'));
-    expect(
-      hrvIntradayResponse.hRVIntraday?.hRvIntraday[0].minutes[1].value[0].rmssd,
-    ).toEqual(48.2);
+    expect(hrvIntradayResponse.hRVIntraday?.minutes[0].value.rmssd).toEqual(
+      45.5,
+    );
+    expect(hrvIntradayResponse.hRVIntraday?.minutes[0].value.coverage).toEqual(
+      0.95,
+    );
+    expect(hrvIntradayResponse.hRVIntraday?.minutes[0].value.hf).toEqual(0.25);
+    expect(hrvIntradayResponse.hRVIntraday?.minutes[0].value.lf).toEqual(0.15);
+    expect(hrvIntradayResponse.hRVIntraday?.minutes[1].minute).toEqual(
+      '2024-10-07T05:12:30.000',
+    );
+    expect(hrvIntradayResponse.hRVIntraday?.minutes[1].value.rmssd).toEqual(
+      48.2,
+    );
+    expect(hrvIntradayResponse.hRVIntraday?.minutes[1].value.coverage).toEqual(
+      0.92,
+    );
+    expect(hrvIntradayResponse.hRVIntraday?.minutes[1].value.hf).toEqual(0.28);
+    expect(hrvIntradayResponse.hRVIntraday?.minutes[1].value.lf).toEqual(0.18);
   });
 
   it('hrvフィールドがない場合でも問題なく型変換出来ること', () => {
@@ -108,55 +70,45 @@ describe('HRVIntraday', () => {
     expect(hrvIntradayResponse.hRVIntraday).toBeUndefined();
   });
 
-  it('複数のvalueがある場合でも問題なく型変換出来ること', () => {
+  it('複数のminutesがある場合でも問題なく型変換出来ること', () => {
     const json = {
       hrv: [
         {
           dateTime: '2024-10-07',
-          minutes: [
-            {
-              minute: new Date('2024-10-07T05:07:30.000+09:00'),
-              value: [
-                {
-                  rmssd: 45.5,
-                  coverage: 0.95,
-                  hf: 0.25,
-                  lf: 0.15,
-                },
-                {
-                  rmssd: 46.8,
-                  coverage: 0.93,
-                  hf: 0.26,
-                  lf: 0.16,
-                },
-              ],
-            },
-          ],
+          value: {
+            dailyRmssd: 45.5,
+            deepRmssd: 52.3,
+          },
         },
       ],
       'hrv-intraday': {
-        hrv: [
+        minutes: [
           {
-            dateTime: '2024-10-07',
-            minutes: [
-              {
-                minute: new Date('2024-10-07T05:07:30.000+09:00'),
-                value: [
-                  {
-                    rmssd: 45.5,
-                    coverage: 0.95,
-                    hf: 0.25,
-                    lf: 0.15,
-                  },
-                  {
-                    rmssd: 46.8,
-                    coverage: 0.93,
-                    hf: 0.26,
-                    lf: 0.16,
-                  },
-                ],
-              },
-            ],
+            minute: '2024-10-07T05:07:30.000',
+            value: {
+              rmssd: 45.5,
+              coverage: 0.95,
+              hf: 0.25,
+              lf: 0.15,
+            },
+          },
+          {
+            minute: '2024-10-07T05:12:30.000',
+            value: {
+              rmssd: 46.8,
+              coverage: 0.93,
+              hf: 0.26,
+              lf: 0.16,
+            },
+          },
+          {
+            minute: '2024-10-07T05:17:30.000',
+            value: {
+              rmssd: 47.2,
+              coverage: 0.94,
+              hf: 0.27,
+              lf: 0.17,
+            },
           },
         ],
       },
@@ -164,14 +116,15 @@ describe('HRVIntraday', () => {
 
     const hrvIntradayResponse = HRVIntradayResponseFromJson(json);
     expect(hrvIntradayResponse.hRVIntraday).toBeDefined();
-    expect(
-      hrvIntradayResponse.hRVIntraday?.hRvIntraday[0].minutes[0].value.length,
-    ).toEqual(2);
-    expect(
-      hrvIntradayResponse.hRVIntraday?.hRvIntraday[0].minutes[0].value[0].rmssd,
-    ).toEqual(45.5);
-    expect(
-      hrvIntradayResponse.hRVIntraday?.hRvIntraday[0].minutes[0].value[1].rmssd,
-    ).toEqual(46.8);
+    expect(hrvIntradayResponse.hRVIntraday?.minutes.length).toEqual(3);
+    expect(hrvIntradayResponse.hRVIntraday?.minutes[0].value.rmssd).toEqual(
+      45.5,
+    );
+    expect(hrvIntradayResponse.hRVIntraday?.minutes[1].value.rmssd).toEqual(
+      46.8,
+    );
+    expect(hrvIntradayResponse.hRVIntraday?.minutes[2].value.rmssd).toEqual(
+      47.2,
+    );
   });
 });

--- a/src/models/hrv-intraday.spec.ts
+++ b/src/models/hrv-intraday.spec.ts
@@ -3,16 +3,7 @@ import { HRVIntradayResponseFromJson } from './hrv-intraday';
 describe('HRVIntraday', () => {
   it('問題なく型変換出来ること', () => {
     const json = {
-      hrv: [
-        {
-          dateTime: '2024-10-07',
-          value: {
-            dailyRmssd: 45.5,
-            deepRmssd: 52.3,
-          },
-        },
-      ],
-      'hrv-intraday': {
+      hrv: {
         minutes: [
           {
             minute: '2024-10-07T05:07:30.000',
@@ -72,16 +63,7 @@ describe('HRVIntraday', () => {
 
   it('複数のminutesがある場合でも問題なく型変換出来ること', () => {
     const json = {
-      hrv: [
-        {
-          dateTime: '2024-10-07',
-          value: {
-            dailyRmssd: 45.5,
-            deepRmssd: 52.3,
-          },
-        },
-      ],
-      'hrv-intraday': {
+      hrv: {
         minutes: [
           {
             minute: '2024-10-07T05:07:30.000',

--- a/src/models/hrv-intraday.spec.ts
+++ b/src/models/hrv-intraday.spec.ts
@@ -182,209 +182,459 @@ describe('HRVIntraday', () => {
     const fitbitJson = {
       hrv: [
         {
-          dateTime: '2025-10-14',
           minutes: [
             {
+              value: {
+                rmssd: 71.841,
+                coverage: 0.864,
+                hf: 512.47,
+                lf: 3213.718,
+              },
               minute: '2025-10-14T02:25:00.000',
-              value: { rmssd: 71.841, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 75.641,
+                coverage: 0.921,
+                hf: 963.91,
+                lf: 2509.695,
+              },
               minute: '2025-10-14T02:30:00.000',
-              value: { rmssd: 75.641, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 79.315,
+                coverage: 0.975,
+                hf: 930.394,
+                lf: 833.697,
+              },
               minute: '2025-10-14T02:35:00.000',
-              value: { rmssd: 79.315, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 83.103,
+                coverage: 0.927,
+                hf: 1208.774,
+                lf: 1836.921,
+              },
               minute: '2025-10-14T02:40:00.000',
-              value: { rmssd: 83.103, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 77.341,
+                coverage: 0.886,
+                hf: 1210.176,
+                lf: 744.785,
+              },
               minute: '2025-10-14T03:00:00.000',
-              value: { rmssd: 77.341, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 45.338,
+                coverage: 0.884,
+                hf: 351.841,
+                lf: 524.131,
+              },
               minute: '2025-10-14T03:05:00.000',
-              value: { rmssd: 45.338, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 63.953,
+                coverage: 0.814,
+                hf: 1030.81,
+                lf: 1277.989,
+              },
               minute: '2025-10-14T03:10:00.000',
-              value: { rmssd: 63.953, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 74.139,
+                coverage: 0.933,
+                hf: 798.525,
+                lf: 1184.857,
+              },
               minute: '2025-10-14T03:20:00.000',
-              value: { rmssd: 74.139, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 29.505,
+                coverage: 0.927,
+                hf: 297.017,
+                lf: 1175.56,
+              },
               minute: '2025-10-14T03:25:00.000',
-              value: { rmssd: 29.505, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 74.782,
+                coverage: 0.914,
+                hf: 705.827,
+                lf: 1793.416,
+              },
               minute: '2025-10-14T03:40:00.000',
-              value: { rmssd: 74.782, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 71.871,
+                coverage: 0.936,
+                hf: 969.725,
+                lf: 471.999,
+              },
               minute: '2025-10-14T03:45:00.000',
-              value: { rmssd: 71.871, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 90.507,
+                coverage: 1.002,
+                hf: 1338.95,
+                lf: 757.661,
+              },
               minute: '2025-10-14T03:50:00.000',
-              value: { rmssd: 90.507, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 128.997,
+                coverage: 0.946,
+                hf: 2488.285,
+                lf: 829.574,
+              },
               minute: '2025-10-14T04:00:00.000',
-              value: { rmssd: 128.997, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 105.231,
+                coverage: 0.942,
+                hf: 1501.178,
+                lf: 331.256,
+              },
               minute: '2025-10-14T04:20:00.000',
-              value: { rmssd: 105.231, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 108.002,
+                coverage: 0.873,
+                hf: 1577.863,
+                lf: 1426.896,
+              },
               minute: '2025-10-14T04:25:00.000',
-              value: { rmssd: 108.002, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 86.191,
+                coverage: 1.004,
+                hf: 1206.419,
+                lf: 482.541,
+              },
               minute: '2025-10-14T04:30:00.000',
-              value: { rmssd: 86.191, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 86.051,
+                coverage: 1.001,
+                hf: 1432.504,
+                lf: 413.246,
+              },
               minute: '2025-10-14T04:35:00.000',
-              value: { rmssd: 86.051, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 76.834,
+                coverage: 1.005,
+                hf: 1134.286,
+                lf: 388.081,
+              },
               minute: '2025-10-14T04:40:00.000',
-              value: { rmssd: 76.834, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 77.561,
+                coverage: 1.005,
+                hf: 1273.712,
+                lf: 281.468,
+              },
               minute: '2025-10-14T04:45:00.000',
-              value: { rmssd: 77.561, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 84.567,
+                coverage: 1.001,
+                hf: 1020.75,
+                lf: 2466.274,
+              },
               minute: '2025-10-14T04:50:00.000',
-              value: { rmssd: 84.567, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 74.39,
+                coverage: 1.005,
+                hf: 1142.572,
+                lf: 166.714,
+              },
               minute: '2025-10-14T04:55:00.000',
-              value: { rmssd: 74.39, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 73.117,
+                coverage: 0.873,
+                hf: 1129.713,
+                lf: 357.414,
+              },
               minute: '2025-10-14T05:00:00.000',
-              value: { rmssd: 73.117, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 77.315,
+                coverage: 0.769,
+                hf: 949.197,
+                lf: 1287.311,
+              },
               minute: '2025-10-14T05:05:00.000',
-              value: { rmssd: 77.315, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 89.261,
+                coverage: 0.715,
+                hf: 1756.907,
+                lf: 3544.92,
+              },
               minute: '2025-10-14T05:10:00.000',
-              value: { rmssd: 89.261, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 75.464,
+                coverage: 0.79,
+                hf: 1268.478,
+                lf: 1082.202,
+              },
               minute: '2025-10-14T05:30:00.000',
-              value: { rmssd: 75.464, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 80.607,
+                coverage: 0.729,
+                hf: 946.016,
+                lf: 2790.421,
+              },
               minute: '2025-10-14T05:35:00.000',
-              value: { rmssd: 80.607, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 100.47,
+                coverage: 0.779,
+                hf: 1601.679,
+                lf: 2930.757,
+              },
               minute: '2025-10-14T05:40:00.000',
-              value: { rmssd: 100.47, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 85.194,
+                coverage: 0.968,
+                hf: 1320.485,
+                lf: 5866.716,
+              },
               minute: '2025-10-14T05:50:00.000',
-              value: { rmssd: 85.194, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 53.26,
+                coverage: 0.777,
+                hf: 620.894,
+                lf: 4851.49,
+              },
               minute: '2025-10-14T05:55:00.000',
-              value: { rmssd: 53.26, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 65.87,
+                coverage: 0.906,
+                hf: 650.705,
+                lf: 2672.076,
+              },
               minute: '2025-10-14T06:00:00.000',
-              value: { rmssd: 65.87, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 79.297,
+                coverage: 0.982,
+                hf: 1174.452,
+                lf: 2733.738,
+              },
               minute: '2025-10-14T06:05:00.000',
-              value: { rmssd: 79.297, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 85.332,
+                coverage: 0.947,
+                hf: 1247.196,
+                lf: 6607.423,
+              },
               minute: '2025-10-14T06:10:00.000',
-              value: { rmssd: 85.332, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 73.544,
+                coverage: 0.795,
+                hf: 813.578,
+                lf: 6011.86,
+              },
               minute: '2025-10-14T06:15:00.000',
-              value: { rmssd: 73.544, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 64.704,
+                coverage: 0.819,
+                hf: 1010.555,
+                lf: 2084.832,
+              },
               minute: '2025-10-14T06:20:00.000',
-              value: { rmssd: 64.704, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 37.107,
+                coverage: 1.003,
+                hf: 239.076,
+                lf: 956.103,
+              },
               minute: '2025-10-14T06:25:00.000',
-              value: { rmssd: 37.107, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 22.198,
+                coverage: 0.726,
+                hf: 117.927,
+                lf: 539.171,
+              },
               minute: '2025-10-14T06:30:00.000',
-              value: { rmssd: 22.198, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 90.307,
+                coverage: 0.851,
+                hf: 1383.067,
+                lf: 9080.806,
+              },
               minute: '2025-10-14T07:30:00.000',
-              value: { rmssd: 90.307, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 87.027,
+                coverage: 0.983,
+                hf: 1650.812,
+                lf: 1554.714,
+              },
               minute: '2025-10-14T07:35:00.000',
-              value: { rmssd: 87.027, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 82.524,
+                coverage: 0.938,
+                hf: 1310.99,
+                lf: 2339.539,
+              },
               minute: '2025-10-14T07:40:00.000',
-              value: { rmssd: 82.524, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 74.364,
+                coverage: 1.005,
+                hf: 1216.019,
+                lf: 1202.025,
+              },
               minute: '2025-10-14T07:45:00.000',
-              value: { rmssd: 74.364, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 87.109,
+                coverage: 0.955,
+                hf: 1284.971,
+                lf: 2648.302,
+              },
               minute: '2025-10-14T07:50:00.000',
-              value: { rmssd: 87.109, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 75.911,
+                coverage: 0.913,
+                hf: 1388.851,
+                lf: 2662.252,
+              },
               minute: '2025-10-14T07:55:00.000',
-              value: { rmssd: 75.911, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 62.548,
+                coverage: 1.003,
+                hf: 1320.046,
+                lf: 342.554,
+              },
               minute: '2025-10-14T08:00:00.000',
-              value: { rmssd: 62.548, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 66.518,
+                coverage: 0.824,
+                hf: 1317.98,
+                lf: 367.929,
+              },
               minute: '2025-10-14T08:05:00.000',
-              value: { rmssd: 66.518, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 70.275,
+                coverage: 0.9,
+                hf: 1193.324,
+                lf: 2493.988,
+              },
               minute: '2025-10-14T08:10:00.000',
-              value: { rmssd: 70.275, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 67.2,
+                coverage: 0.918,
+                hf: 744.026,
+                lf: 2171.039,
+              },
               minute: '2025-10-14T08:30:00.000',
-              value: { rmssd: 67.2, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 67.444,
+                coverage: 0.939,
+                hf: 911.145,
+                lf: 4310.475,
+              },
               minute: '2025-10-14T08:35:00.000',
-              value: { rmssd: 67.444, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 69.976,
+                coverage: 0.989,
+                hf: 1457.141,
+                lf: 1684.807,
+              },
               minute: '2025-10-14T08:40:00.000',
-              value: { rmssd: 69.976, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 67.085,
+                coverage: 0.991,
+                hf: 1168.868,
+                lf: 622.291,
+              },
               minute: '2025-10-14T08:45:00.000',
-              value: { rmssd: 67.085, coverage: 0, hf: 0, lf: 0 },
             },
             {
+              value: {
+                rmssd: 67.336,
+                coverage: 0.929,
+                hf: 786.823,
+                lf: 3916.351,
+              },
               minute: '2025-10-14T08:50:00.000',
-              value: { rmssd: 67.336, coverage: 0, hf: 0, lf: 0 },
             },
           ],
+          dateTime: '2025-10-14',
         },
       ],
     };
@@ -405,6 +655,7 @@ describe('HRVIntraday', () => {
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[0].value.rmssd).toEqual(
       71.841,
     );
+
     expect(hrvIntradayResponse.hRVIntraday[0].minutes[1].minute).toEqual(
       new Date('2025-10-14T02:30:00.000+09:00'),
     );

--- a/src/models/hrv-intraday.spec.ts
+++ b/src/models/hrv-intraday.spec.ts
@@ -3,109 +3,127 @@ import { HRVIntradayResponseFromJson } from './hrv-intraday';
 describe('HRVIntraday', () => {
   it('問題なく型変換出来ること', () => {
     const json = {
-      hrv: {
-        minutes: [
-          {
-            minute: '2024-10-07T05:07:30.000',
-            value: {
-              rmssd: 45.5,
-              coverage: 0.95,
-              hf: 0.25,
-              lf: 0.15,
+      hrv: [
+        {
+          dateTime: '2024-10-07',
+          minutes: [
+            {
+              minute: '2024-10-07T05:07:30.000',
+              value: {
+                rmssd: 45.5,
+                coverage: 0.95,
+                hf: 0.25,
+                lf: 0.15,
+              },
             },
-          },
-          {
-            minute: '2024-10-07T05:12:30.000',
-            value: {
-              rmssd: 48.2,
-              coverage: 0.92,
-              hf: 0.28,
-              lf: 0.18,
+            {
+              minute: '2024-10-07T05:12:30.000',
+              value: {
+                rmssd: 48.2,
+                coverage: 0.92,
+                hf: 0.28,
+                lf: 0.18,
+              },
             },
-          },
-        ],
-      },
+          ],
+        },
+      ],
     };
 
     const hrvIntradayResponse = HRVIntradayResponseFromJson(json);
     expect(hrvIntradayResponse.hRVIntraday).toBeDefined();
-    expect(hrvIntradayResponse.hRVIntraday?.minutes.length).toEqual(2);
-    expect(hrvIntradayResponse.hRVIntraday?.minutes[0].minute).toEqual(
+    expect(hrvIntradayResponse.hRVIntraday.length).toEqual(1);
+    expect(hrvIntradayResponse.hRVIntraday[0].localDate).toEqual('2024-10-07');
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes.length).toEqual(2);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[0].minute).toEqual(
       '2024-10-07T05:07:30.000',
     );
-    expect(hrvIntradayResponse.hRVIntraday?.minutes[0].value.rmssd).toEqual(
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[0].value.rmssd).toEqual(
       45.5,
     );
-    expect(hrvIntradayResponse.hRVIntraday?.minutes[0].value.coverage).toEqual(
-      0.95,
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[0].value.coverage,
+    ).toEqual(0.95);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[0].value.hf).toEqual(
+      0.25,
     );
-    expect(hrvIntradayResponse.hRVIntraday?.minutes[0].value.hf).toEqual(0.25);
-    expect(hrvIntradayResponse.hRVIntraday?.minutes[0].value.lf).toEqual(0.15);
-    expect(hrvIntradayResponse.hRVIntraday?.minutes[1].minute).toEqual(
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[0].value.lf).toEqual(
+      0.15,
+    );
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[1].minute).toEqual(
       '2024-10-07T05:12:30.000',
     );
-    expect(hrvIntradayResponse.hRVIntraday?.minutes[1].value.rmssd).toEqual(
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[1].value.rmssd).toEqual(
       48.2,
     );
-    expect(hrvIntradayResponse.hRVIntraday?.minutes[1].value.coverage).toEqual(
-      0.92,
+    expect(
+      hrvIntradayResponse.hRVIntraday[0].minutes[1].value.coverage,
+    ).toEqual(0.92);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[1].value.hf).toEqual(
+      0.28,
     );
-    expect(hrvIntradayResponse.hRVIntraday?.minutes[1].value.hf).toEqual(0.28);
-    expect(hrvIntradayResponse.hRVIntraday?.minutes[1].value.lf).toEqual(0.18);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[1].value.lf).toEqual(
+      0.18,
+    );
   });
 
   it('hrvフィールドがない場合でも問題なく型変換出来ること', () => {
     const json = {};
 
     const hrvIntradayResponse = HRVIntradayResponseFromJson(json);
-    expect(hrvIntradayResponse.hRVIntraday).toBeUndefined();
+    expect(hrvIntradayResponse.hRVIntraday.length).toEqual(0);
   });
 
   it('複数のminutesがある場合でも問題なく型変換出来ること', () => {
     const json = {
-      hrv: {
-        minutes: [
-          {
-            minute: '2024-10-07T05:07:30.000',
-            value: {
-              rmssd: 45.5,
-              coverage: 0.95,
-              hf: 0.25,
-              lf: 0.15,
+      hrv: [
+        {
+          dateTime: '2024-10-07',
+          minutes: [
+            {
+              minute: '2024-10-07T05:07:30.000',
+              value: {
+                rmssd: 45.5,
+                coverage: 0.95,
+                hf: 0.25,
+                lf: 0.15,
+              },
             },
-          },
-          {
-            minute: '2024-10-07T05:12:30.000',
-            value: {
-              rmssd: 46.8,
-              coverage: 0.93,
-              hf: 0.26,
-              lf: 0.16,
+            {
+              minute: '2024-10-07T05:12:30.000',
+              value: {
+                rmssd: 46.8,
+                coverage: 0.93,
+                hf: 0.26,
+                lf: 0.16,
+              },
             },
-          },
-          {
-            minute: '2024-10-07T05:17:30.000',
-            value: {
-              rmssd: 47.2,
-              coverage: 0.94,
-              hf: 0.27,
-              lf: 0.17,
+            {
+              minute: '2024-10-07T05:17:30.000',
+              value: {
+                rmssd: 47.2,
+                coverage: 0.94,
+                hf: 0.27,
+                lf: 0.17,
+              },
             },
-          },
-        ],
-      },
+          ],
+        },
+      ],
     };
 
     const hrvIntradayResponse = HRVIntradayResponseFromJson(json);
     expect(hrvIntradayResponse.hRVIntraday).toBeDefined();
-    expect(hrvIntradayResponse.hRVIntraday?.minutes.length).toEqual(3);
-    expect(hrvIntradayResponse.hRVIntraday?.minutes[0].value.rmssd).toEqual(
+    expect(hrvIntradayResponse.hRVIntraday.length).toEqual(1);
+    expect(hrvIntradayResponse.hRVIntraday[0].localDate).toEqual('2024-10-07');
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes.length).toEqual(3);
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[0].value.rmssd).toEqual(
       45.5,
     );
-    expect(hrvIntradayResponse.hRVIntraday?.minutes[1].value.rmssd).toEqual(
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[1].value.rmssd).toEqual(
       46.8,
     );
-    expect(hrvIntradayResponse.hRVIntraday?.minutes[2].value.rmssd).toEqual(
+    expect(hrvIntradayResponse.hRVIntraday[0].minutes[2].value.rmssd).toEqual(
       47.2,
     );
   });

--- a/src/models/hrv-intraday.ts
+++ b/src/models/hrv-intraday.ts
@@ -14,8 +14,8 @@ export interface HRVIntradayResponse {
 export function HRVIntradayResponseFromJson(
   json: unknown,
 ): HRVIntradayResponse {
-  const hRVIntraday = exists(json, 'hrv-intraday')
-    ? HRVIntradayFromJson(get<unknown>(json, 'hrv-intraday'))
+  const hRVIntraday = exists(json, 'hrv')
+    ? HRVIntradayFromJson(get<unknown>(json, 'hrv'))
     : undefined;
 
   return {

--- a/src/models/hrv-intraday.ts
+++ b/src/models/hrv-intraday.ts
@@ -1,13 +1,9 @@
 import { exists, get } from '../utils/types.utils';
 
 /**
- * 日中の心拍変動のデータのレスポンス
+ * 心拍変動の詳細データのレスポンス
  */
-export interface HRVResponse {
-  /**
-   * 心拍変動のデータ一覧
-   */
-  hRV: HRVData[];
+export interface HRVIntradayResponse {
   /**
    * 心拍変動の詳細データ
    * 取得にはIntradayの申請もしくはApplicationTypeがPersonalである必要があります。
@@ -15,52 +11,15 @@ export interface HRVResponse {
   hRVIntraday?: HRVIntraday;
 }
 
-export function HRVResponseFromJson(json: unknown): HRVResponse {
-  const hRV = get<unknown[]>(json, 'hrv').map((data) => HRVDataFromJson(data));
+export function HRVIntradayResponseFromJson(
+  json: unknown,
+): HRVIntradayResponse {
   const hRVIntraday = exists(json, 'hrv')
     ? HRVIntradayFromJson(get<unknown[]>(json, 'hrv-intraday'))
     : undefined;
 
   return {
-    hRV,
     hRVIntraday,
-  };
-}
-
-export interface HRVData {
-  /**
-   * 睡眠ログのローカル日付
-   * yyyy-MM-dd
-   */
-  localDate: string;
-  /**
-   *
-   */
-  value: HRVValue[];
-}
-
-export interface HRVValue {
-  /**
-   * 心拍間で1日の短期的な変動(ミリ秒)
-   */
-  dailyRmssd: number;
-  /**
-   * 心拍間で1日の睡眠中における短期的な変動(ミリ秒)
-   */
-  deepRmssd: number;
-}
-
-function HRVDataFromJson(json: unknown): HRVData {
-  return {
-    localDate: get<string>(json, 'dateTime'),
-    value: get<unknown[]>(json, 'value').map((data) => HRVValueFromJson(data)),
-  };
-}
-
-function HRVValueFromJson(json: unknown): HRVValue {
-  return {
-    dailyRmssd: get<number>(json, 'dailyRmssd'),
-    deepRmssd: get<number>(json, 'deepRmssd'),
   };
 }
 

--- a/src/models/hrv-intraday.ts
+++ b/src/models/hrv-intraday.ts
@@ -8,18 +8,18 @@ export interface HRVIntradayResponse {
    * 心拍変動の詳細データ
    * 取得にはIntradayの申請もしくはApplicationTypeがPersonalである必要があります。
    */
-  hRVIntraday?: HRVIntraday;
+  hRVIntraday: HRVIntraday[];
 }
 
 export function HRVIntradayResponseFromJson(
   json: unknown,
 ): HRVIntradayResponse {
-  const hRVIntraday = exists(json, 'hrv')
-    ? HRVIntradayFromJson(get<unknown>(json, 'hrv'))
-    : undefined;
+  const hrvData = exists(json, 'hrv') ? get<unknown[]>(json, 'hrv') : [];
+
+  const hRVIntraday = hrvData.map((data) => HRVIntradayFromJson(data));
 
   return {
-    hRVIntraday,
+    hRVIntraday: hRVIntraday,
   };
 }
 
@@ -28,6 +28,11 @@ export function HRVIntradayResponseFromJson(
  * 取得にはIntradayの申請もしくはApplicationTypeがPersonalである必要があります。
  */
 export interface HRVIntraday {
+  /**
+   * ローカル日付
+   * 'yyyy-MM-dd'
+   */
+  localDate: string;
   /**
    * 特定の時間ごとのデータ
    */
@@ -78,6 +83,7 @@ export interface HRVIntradayValue {
 
 function HRVIntradayFromJson(json: unknown): HRVIntraday {
   return {
+    localDate: get<string>(json, 'dateTime'),
     minutes: get<unknown[]>(json, 'minutes').map((data) =>
       HRVIntradayMinuteDataFromJson(data),
     ),

--- a/src/models/hrv-intraday.ts
+++ b/src/models/hrv-intraday.ts
@@ -14,8 +14,8 @@ export interface HRVIntradayResponse {
 export function HRVIntradayResponseFromJson(
   json: unknown,
 ): HRVIntradayResponse {
-  const hRVIntraday = exists(json, 'hrv')
-    ? HRVIntradayFromJson(get<unknown[]>(json, 'hrv-intraday'))
+  const hRVIntraday = exists(json, 'hrv-intraday')
+    ? HRVIntradayFromJson(get<unknown>(json, 'hrv-intraday'))
     : undefined;
 
   return {
@@ -29,21 +29,6 @@ export function HRVIntradayResponseFromJson(
  */
 export interface HRVIntraday {
   /**
-   * 心拍変動の詳細データ
-   */
-  hRvIntraday: HRVIntradayData[];
-}
-
-/**
- * 心拍変動の詳細データ
- */
-export interface HRVIntradayData {
-  /**
-   * 睡眠ログが記録された時のローカル日時
-   * 'yyyy-MM-dd'
-   */
-  localDate: string;
-  /**
    * 特定の時間ごとのデータ
    */
   minutes: HRVIntradayMinute[];
@@ -56,11 +41,11 @@ export interface HRVIntradayMinute {
   /**
    * 時間
    */
-  minute: Date;
+  minute: string;
   /**
    * 心拍変動の詳細データ
    */
-  value: HRVIntradayValue[];
+  value: HRVIntradayValue;
 }
 
 /**
@@ -93,15 +78,6 @@ export interface HRVIntradayValue {
 
 function HRVIntradayFromJson(json: unknown): HRVIntraday {
   return {
-    hRvIntraday: get<unknown[]>(json, 'hrv').map((data) =>
-      HRVIntradayDataFromJson(data),
-    ),
-  };
-}
-
-function HRVIntradayDataFromJson(json: unknown): HRVIntradayData {
-  return {
-    localDate: get<string>(json, 'dateTime'),
     minutes: get<unknown[]>(json, 'minutes').map((data) =>
       HRVIntradayMinuteDataFromJson(data),
     ),
@@ -110,10 +86,8 @@ function HRVIntradayDataFromJson(json: unknown): HRVIntradayData {
 
 function HRVIntradayMinuteDataFromJson(json: unknown): HRVIntradayMinute {
   return {
-    minute: get<Date>(json, 'minute'),
-    value: get<unknown[]>(json, 'value').map((data) =>
-      HRVIntradayValueDataFromJson(data),
-    ),
+    minute: get<string>(json, 'minute'),
+    value: HRVIntradayValueDataFromJson(get<unknown>(json, 'value')),
   };
 }
 

--- a/src/models/hrv-summary.spec.ts
+++ b/src/models/hrv-summary.spec.ts
@@ -1,0 +1,67 @@
+import { HRVSummaryResponseFromJson } from './hrv-summary';
+
+describe('HRVSummary', () => {
+  it('問題なく型変換出来ること', () => {
+    const json = {
+      hrv: [
+        {
+          dateTime: '2024-10-07',
+          value: [
+            {
+              dailyRmssd: 45.5,
+              deepRmssd: 52.3,
+            },
+          ],
+        },
+        {
+          dateTime: '2024-10-08',
+          value: [
+            {
+              dailyRmssd: 48.2,
+              deepRmssd: 55.1,
+            },
+          ],
+        },
+      ],
+    };
+
+    const hrvSummaryResponse = HRVSummaryResponseFromJson(json);
+    expect(hrvSummaryResponse.hRV.length).toEqual(2);
+    expect(hrvSummaryResponse.hRV[0].localDate).toEqual('2024-10-07');
+    expect(hrvSummaryResponse.hRV[0].value.length).toEqual(1);
+    expect(hrvSummaryResponse.hRV[0].value[0].dailyRmssd).toEqual(45.5);
+    expect(hrvSummaryResponse.hRV[0].value[0].deepRmssd).toEqual(52.3);
+    expect(hrvSummaryResponse.hRV[1].localDate).toEqual('2024-10-08');
+    expect(hrvSummaryResponse.hRV[1].value[0].dailyRmssd).toEqual(48.2);
+    expect(hrvSummaryResponse.hRV[1].value[0].deepRmssd).toEqual(55.1);
+  });
+
+  it('複数のvalueがある場合でも問題なく型変換出来ること', () => {
+    const json = {
+      hrv: [
+        {
+          dateTime: '2024-10-07',
+          value: [
+            {
+              dailyRmssd: 45.5,
+              deepRmssd: 52.3,
+            },
+            {
+              dailyRmssd: 46.8,
+              deepRmssd: 53.7,
+            },
+          ],
+        },
+      ],
+    };
+
+    const hrvSummaryResponse = HRVSummaryResponseFromJson(json);
+    expect(hrvSummaryResponse.hRV.length).toEqual(1);
+    expect(hrvSummaryResponse.hRV[0].localDate).toEqual('2024-10-07');
+    expect(hrvSummaryResponse.hRV[0].value.length).toEqual(2);
+    expect(hrvSummaryResponse.hRV[0].value[0].dailyRmssd).toEqual(45.5);
+    expect(hrvSummaryResponse.hRV[0].value[0].deepRmssd).toEqual(52.3);
+    expect(hrvSummaryResponse.hRV[0].value[1].dailyRmssd).toEqual(46.8);
+    expect(hrvSummaryResponse.hRV[0].value[1].deepRmssd).toEqual(53.7);
+  });
+});

--- a/src/models/hrv-summary.spec.ts
+++ b/src/models/hrv-summary.spec.ts
@@ -6,21 +6,17 @@ describe('HRVSummary', () => {
       hrv: [
         {
           dateTime: '2024-10-07',
-          value: [
-            {
-              dailyRmssd: 45.5,
-              deepRmssd: 52.3,
-            },
-          ],
+          value: {
+            dailyRmssd: 45.5,
+            deepRmssd: 52.3,
+          },
         },
         {
           dateTime: '2024-10-08',
-          value: [
-            {
-              dailyRmssd: 48.2,
-              deepRmssd: 55.1,
-            },
-          ],
+          value: {
+            dailyRmssd: 48.2,
+            deepRmssd: 55.1,
+          },
         },
       ],
     };
@@ -28,40 +24,50 @@ describe('HRVSummary', () => {
     const hrvSummaryResponse = HRVSummaryResponseFromJson(json);
     expect(hrvSummaryResponse.hRV.length).toEqual(2);
     expect(hrvSummaryResponse.hRV[0].localDate).toEqual('2024-10-07');
-    expect(hrvSummaryResponse.hRV[0].value.length).toEqual(1);
-    expect(hrvSummaryResponse.hRV[0].value[0].dailyRmssd).toEqual(45.5);
-    expect(hrvSummaryResponse.hRV[0].value[0].deepRmssd).toEqual(52.3);
+    expect(hrvSummaryResponse.hRV[0].value.dailyRmssd).toEqual(45.5);
+    expect(hrvSummaryResponse.hRV[0].value.deepRmssd).toEqual(52.3);
     expect(hrvSummaryResponse.hRV[1].localDate).toEqual('2024-10-08');
-    expect(hrvSummaryResponse.hRV[1].value[0].dailyRmssd).toEqual(48.2);
-    expect(hrvSummaryResponse.hRV[1].value[0].deepRmssd).toEqual(55.1);
+    expect(hrvSummaryResponse.hRV[1].value.dailyRmssd).toEqual(48.2);
+    expect(hrvSummaryResponse.hRV[1].value.deepRmssd).toEqual(55.1);
   });
 
-  it('複数のvalueがある場合でも問題なく型変換出来ること', () => {
+  it('複数の日付のデータがある場合でも問題なく型変換出来ること', () => {
     const json = {
       hrv: [
         {
           dateTime: '2024-10-07',
-          value: [
-            {
-              dailyRmssd: 45.5,
-              deepRmssd: 52.3,
-            },
-            {
-              dailyRmssd: 46.8,
-              deepRmssd: 53.7,
-            },
-          ],
+          value: {
+            dailyRmssd: 45.5,
+            deepRmssd: 52.3,
+          },
+        },
+        {
+          dateTime: '2024-10-08',
+          value: {
+            dailyRmssd: 46.8,
+            deepRmssd: 53.7,
+          },
+        },
+        {
+          dateTime: '2024-10-09',
+          value: {
+            dailyRmssd: 47.2,
+            deepRmssd: 54.1,
+          },
         },
       ],
     };
 
     const hrvSummaryResponse = HRVSummaryResponseFromJson(json);
-    expect(hrvSummaryResponse.hRV.length).toEqual(1);
+    expect(hrvSummaryResponse.hRV.length).toEqual(3);
     expect(hrvSummaryResponse.hRV[0].localDate).toEqual('2024-10-07');
-    expect(hrvSummaryResponse.hRV[0].value.length).toEqual(2);
-    expect(hrvSummaryResponse.hRV[0].value[0].dailyRmssd).toEqual(45.5);
-    expect(hrvSummaryResponse.hRV[0].value[0].deepRmssd).toEqual(52.3);
-    expect(hrvSummaryResponse.hRV[0].value[1].dailyRmssd).toEqual(46.8);
-    expect(hrvSummaryResponse.hRV[0].value[1].deepRmssd).toEqual(53.7);
+    expect(hrvSummaryResponse.hRV[0].value.dailyRmssd).toEqual(45.5);
+    expect(hrvSummaryResponse.hRV[0].value.deepRmssd).toEqual(52.3);
+    expect(hrvSummaryResponse.hRV[1].localDate).toEqual('2024-10-08');
+    expect(hrvSummaryResponse.hRV[1].value.dailyRmssd).toEqual(46.8);
+    expect(hrvSummaryResponse.hRV[1].value.deepRmssd).toEqual(53.7);
+    expect(hrvSummaryResponse.hRV[2].localDate).toEqual('2024-10-09');
+    expect(hrvSummaryResponse.hRV[2].value.dailyRmssd).toEqual(47.2);
+    expect(hrvSummaryResponse.hRV[2].value.deepRmssd).toEqual(54.1);
   });
 });

--- a/src/models/hrv-summary.spec.ts
+++ b/src/models/hrv-summary.spec.ts
@@ -22,13 +22,13 @@ describe('HRVSummary', () => {
     };
 
     const hrvSummaryResponse = HRVSummaryResponseFromJson(json);
-    expect(hrvSummaryResponse.hRV.length).toEqual(2);
-    expect(hrvSummaryResponse.hRV[0].localDate).toEqual('2024-10-07');
-    expect(hrvSummaryResponse.hRV[0].value.dailyRmssd).toEqual(45.5);
-    expect(hrvSummaryResponse.hRV[0].value.deepRmssd).toEqual(52.3);
-    expect(hrvSummaryResponse.hRV[1].localDate).toEqual('2024-10-08');
-    expect(hrvSummaryResponse.hRV[1].value.dailyRmssd).toEqual(48.2);
-    expect(hrvSummaryResponse.hRV[1].value.deepRmssd).toEqual(55.1);
+    expect(hrvSummaryResponse.hRVSummary.length).toEqual(2);
+    expect(hrvSummaryResponse.hRVSummary[0].localDate).toEqual('2024-10-07');
+    expect(hrvSummaryResponse.hRVSummary[0].value.dailyRmssd).toEqual(45.5);
+    expect(hrvSummaryResponse.hRVSummary[0].value.deepRmssd).toEqual(52.3);
+    expect(hrvSummaryResponse.hRVSummary[1].localDate).toEqual('2024-10-08');
+    expect(hrvSummaryResponse.hRVSummary[1].value.dailyRmssd).toEqual(48.2);
+    expect(hrvSummaryResponse.hRVSummary[1].value.deepRmssd).toEqual(55.1);
   });
 
   it('複数の日付のデータがある場合でも問題なく型変換出来ること', () => {
@@ -59,15 +59,15 @@ describe('HRVSummary', () => {
     };
 
     const hrvSummaryResponse = HRVSummaryResponseFromJson(json);
-    expect(hrvSummaryResponse.hRV.length).toEqual(3);
-    expect(hrvSummaryResponse.hRV[0].localDate).toEqual('2024-10-07');
-    expect(hrvSummaryResponse.hRV[0].value.dailyRmssd).toEqual(45.5);
-    expect(hrvSummaryResponse.hRV[0].value.deepRmssd).toEqual(52.3);
-    expect(hrvSummaryResponse.hRV[1].localDate).toEqual('2024-10-08');
-    expect(hrvSummaryResponse.hRV[1].value.dailyRmssd).toEqual(46.8);
-    expect(hrvSummaryResponse.hRV[1].value.deepRmssd).toEqual(53.7);
-    expect(hrvSummaryResponse.hRV[2].localDate).toEqual('2024-10-09');
-    expect(hrvSummaryResponse.hRV[2].value.dailyRmssd).toEqual(47.2);
-    expect(hrvSummaryResponse.hRV[2].value.deepRmssd).toEqual(54.1);
+    expect(hrvSummaryResponse.hRVSummary.length).toEqual(3);
+    expect(hrvSummaryResponse.hRVSummary[0].localDate).toEqual('2024-10-07');
+    expect(hrvSummaryResponse.hRVSummary[0].value.dailyRmssd).toEqual(45.5);
+    expect(hrvSummaryResponse.hRVSummary[0].value.deepRmssd).toEqual(52.3);
+    expect(hrvSummaryResponse.hRVSummary[1].localDate).toEqual('2024-10-08');
+    expect(hrvSummaryResponse.hRVSummary[1].value.dailyRmssd).toEqual(46.8);
+    expect(hrvSummaryResponse.hRVSummary[1].value.deepRmssd).toEqual(53.7);
+    expect(hrvSummaryResponse.hRVSummary[2].localDate).toEqual('2024-10-09');
+    expect(hrvSummaryResponse.hRVSummary[2].value.dailyRmssd).toEqual(47.2);
+    expect(hrvSummaryResponse.hRVSummary[2].value.deepRmssd).toEqual(54.1);
   });
 });

--- a/src/models/hrv-summary.ts
+++ b/src/models/hrv-summary.ts
@@ -25,9 +25,9 @@ export interface HRVData {
    */
   localDate: string;
   /**
-   *
+   * 心拍変動の値
    */
-  value: HRVValue[];
+  value: HRVValue;
 }
 
 export interface HRVValue {
@@ -44,7 +44,7 @@ export interface HRVValue {
 function HRVDataFromJson(json: unknown): HRVData {
   return {
     localDate: get<string>(json, 'dateTime'),
-    value: get<unknown[]>(json, 'value').map((data) => HRVValueFromJson(data)),
+    value: HRVValueFromJson(get<unknown>(json, 'value')),
   };
 }
 

--- a/src/models/hrv-summary.ts
+++ b/src/models/hrv-summary.ts
@@ -1,0 +1,56 @@
+import { get } from '../utils/types.utils';
+
+/**
+ * 心拍変動のデータのレスポンス
+ */
+export interface HRVSummaryResponse {
+  /**
+   * 心拍変動のデータ一覧
+   */
+  hRV: HRVData[];
+}
+
+export function HRVSummaryResponseFromJson(json: unknown): HRVSummaryResponse {
+  const hRV = get<unknown[]>(json, 'hrv').map((data) => HRVDataFromJson(data));
+
+  return {
+    hRV,
+  };
+}
+
+export interface HRVData {
+  /**
+   * 睡眠ログのローカル日付
+   * yyyy-MM-dd
+   */
+  localDate: string;
+  /**
+   *
+   */
+  value: HRVValue[];
+}
+
+export interface HRVValue {
+  /**
+   * 心拍間で1日の短期的な変動(ミリ秒)
+   */
+  dailyRmssd: number;
+  /**
+   * 心拍間で1日の睡眠中における短期的な変動(ミリ秒)
+   */
+  deepRmssd: number;
+}
+
+function HRVDataFromJson(json: unknown): HRVData {
+  return {
+    localDate: get<string>(json, 'dateTime'),
+    value: get<unknown[]>(json, 'value').map((data) => HRVValueFromJson(data)),
+  };
+}
+
+function HRVValueFromJson(json: unknown): HRVValue {
+  return {
+    dailyRmssd: get<number>(json, 'dailyRmssd'),
+    deepRmssd: get<number>(json, 'deepRmssd'),
+  };
+}

--- a/src/models/hrv-summary.ts
+++ b/src/models/hrv-summary.ts
@@ -7,14 +7,14 @@ export interface HRVSummaryResponse {
   /**
    * 心拍変動のデータ一覧
    */
-  hRV: HRVData[];
+  hRVSummary: HRVData[];
 }
 
 export function HRVSummaryResponseFromJson(json: unknown): HRVSummaryResponse {
   const hRV = get<unknown[]>(json, 'hrv').map((data) => HRVDataFromJson(data));
 
   return {
-    hRV,
+    hRVSummary: hRV,
   };
 }
 

--- a/src/models/hrv.ts
+++ b/src/models/hrv.ts
@@ -1,0 +1,168 @@
+import { exists, get } from '../utils/types.utils';
+
+/**
+ * 日中の心拍変動のデータのレスポンス
+ */
+export interface HRVResponse {
+  /**
+   * 心拍変動のデータ一覧
+   */
+  hRV: HRVData[];
+  /**
+   * 心拍変動の詳細データ
+   * 取得にはIntradayの申請もしくはApplicationTypeがPersonalである必要があります。
+   */
+  hRVIntraday?: HRVIntraday;
+}
+
+export function HRVResponseFromJson(json: unknown): HRVResponse {
+  const hRV = get<unknown[]>(json, 'hrv').map((data) => HRVDataFromJson(data));
+  const hRVIntraday = exists(json, 'hrv')
+    ? HRVIntradayFromJson(get<unknown[]>(json, 'hrv-intraday'))
+    : undefined;
+
+  return {
+    hRV,
+    hRVIntraday,
+  };
+}
+
+export interface HRVData {
+  /**
+   * 睡眠ログのローカル日付
+   * yyyy-MM-dd
+   */
+  localDate: string;
+  /**
+   *
+   */
+  value: HRVValue[];
+}
+
+export interface HRVValue {
+  /**
+   * 心拍間で1日の短期的な変動(ミリ秒)
+   */
+  dailyRmssd: number;
+  /**
+   * 心拍間で1日の睡眠中における短期的な変動(ミリ秒)
+   */
+  deepRmssd: number;
+}
+
+function HRVDataFromJson(json: unknown): HRVData {
+  return {
+    localDate: get<string>(json, 'dateTime'),
+    value: get<unknown[]>(json, 'value').map((data) => HRVValueFromJson(data)),
+  };
+}
+
+function HRVValueFromJson(json: unknown): HRVValue {
+  return {
+    dailyRmssd: get<number>(json, 'dailyRmssd'),
+    deepRmssd: get<number>(json, 'deepRmssd'),
+  };
+}
+
+/**
+ * 心拍変動の詳細
+ * 取得にはIntradayの申請もしくはApplicationTypeがPersonalである必要があります。
+ */
+export interface HRVIntraday {
+  /**
+   * 心拍変動の詳細データ
+   */
+  hRvIntraday: HRVIntradayData[];
+}
+
+/**
+ * 心拍変動の詳細データ
+ */
+export interface HRVIntradayData {
+  /**
+   * 睡眠ログが記録された時のローカル日時
+   * 'yyyy-MM-dd'
+   */
+  localDate: string;
+  /**
+   * 特定の時間ごとのデータ
+   */
+  minutes: HRVIntradayMinute[];
+}
+
+/**
+ * 心拍変動における特定の時間の詳細データ
+ */
+export interface HRVIntradayMinute {
+  /**
+   * 時間
+   */
+  minute: Date;
+  /**
+   * 心拍変動の詳細データ
+   */
+  value: HRVIntradayValue[];
+}
+
+/**
+ * 心拍変動の詳細データ
+ */
+export interface HRVIntradayValue {
+  /**
+   * 心拍数の短期的な変動(ミリ秒)
+   * @type {number}
+   */
+  rmssd: number;
+  /**
+   * 心拍間隔の数の観点から見たデータの完全性
+   * @type {number}
+   */
+  coverage: number;
+  /**
+   *  高周波帯域内の心拍感覚変動の強さ(Hz)
+   *  範囲(0.15 Hz - 0.4 Hz)
+   *  @Type {number}
+   */
+  hf: number;
+  /**
+   * 低周波帯域内の心拍感覚変動の強さ(Hz)
+   *  範囲(0.04 Hz - 0.15 Hz)
+   *  @Type {number}
+   */
+  lf: number;
+}
+
+function HRVIntradayFromJson(json: unknown): HRVIntraday {
+  return {
+    hRvIntraday: get<unknown[]>(json, 'hrv').map((data) =>
+      HRVIntradayDataFromJson(data),
+    ),
+  };
+}
+
+function HRVIntradayDataFromJson(json: unknown): HRVIntradayData {
+  return {
+    localDate: get<string>(json, 'dateTime'),
+    minutes: get<unknown[]>(json, 'minutes').map((data) =>
+      HRVIntradayMinuteDataFromJson(data),
+    ),
+  };
+}
+
+function HRVIntradayMinuteDataFromJson(json: unknown): HRVIntradayMinute {
+  return {
+    minute: get<Date>(json, 'minute'),
+    value: get<unknown[]>(json, 'value').map((data) =>
+      HRVIntradayValueDataFromJson(data),
+    ),
+  };
+}
+
+function HRVIntradayValueDataFromJson(json: unknown): HRVIntradayValue {
+  return {
+    rmssd: get<number>(json, 'rmssd'),
+    coverage: get<number>(json, 'coverage'),
+    hf: get<number>(json, 'hf'),
+    lf: get<number>(json, 'lf'),
+  };
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -3,3 +3,4 @@ export * from './heart-rate';
 export * from './oauth';
 export * from './errors';
 export * from './sleep';
+export * from './hrv';

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -3,4 +3,5 @@ export * from './heart-rate';
 export * from './oauth';
 export * from './errors';
 export * from './sleep';
-export * from './hrv';
+export * from './hrv-summary';
+export * from './hrv-intraday';


### PR DESCRIPTION
## リンク
https://www.notion.so/thephage/fitbit-client-api-hrv-2947ef398b7380b19530d2247067a0e2?source=copy_link

## 変更内容
- 種別: 機能追加 
HRV-summary
HRV-intraday
のapi実装
- 内容:
以下のAPIを叩いた時に以下のレスポンスを得られる。なかった場合は、`[]`になる
/fitbit/heartrate/summary
```
{
  "hrv": [
    {
      "value": {
        "dailyRmssd": number,
        "deepRmssd": number
      },
      "localDate": string
    }
  ]
}
```
/fitbit/heartrate/intraday
```
{
  "hrv": [
    {
      "minutes": [
        {
          "minute": Date,
          "value": {
            "rmssd": number,
            "coverage": number,
            "hf": number,
            "lf": number
          }
        },
      …
      ],
      "localDate": string
    }
  ]
}
```

## 確認方法
sample 実行時にエラーを出さずに取得できること
testが通ること
minuteの値がJSTではなくUTC+09:00になっていること

## スクリーンショット (任意)

|            Before            |            After             |
|:----------------------------:|:----------------------------:|
|  <img src="" width="300" />  |  <img src="" width="300" />  |
| <video src="" width="300" /> | <video src="" width="300" /> |

## 注意事項
- [x] APIクライアントのリリースが必要
- [ ] DBのマイグレーションが必要
- [ ] 環境変数の追加が必要
- [ ] その他（具体的に記載してください）
